### PR TITLE
README: use gnu-toolchain for configure step

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,6 @@ install path, and that the riscv-gcc package is installed.
 
     $ mkdir build
     $ cd build
-    $ CC=riscv-gcc ../configure --prefix=$RISCV/riscv-elf --host=riscv
+    $ CC=riscv64-unknown-elf-gcc ../configure --prefix=$RISCV/riscv64-unknown-elf --host=riscv
     $ make
     $ make install


### PR DESCRIPTION
Updated the README to use the riscv-gnu-toolchain paths.
