### PR TITLE
Change the behavior of the DESTDIR make variable

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -55,14 +55,14 @@ enable_stow  := @enable_stow@
 
 ifeq ($(enable_stow),yes)
   stow_pkg_dir := $(prefix)/pkgs
-  DESTDIR ?= $(stow_pkg_dir)/$(project_name)-$(project_ver)
+  INSTALLDIR ?= $(DESTDIR)/$(stow_pkg_dir)/$(project_name)-$(project_ver)
 else
-  DESTDIR ?= $(prefix)
+  INSTALLDIR ?= $(DESTDIR)/$(prefix)
 endif
 
-install_hdrs_dir := $(DESTDIR)/include/$(project_name)
-install_libs_dir := $(DESTDIR)/lib/$(project_name)
-install_exes_dir := $(DESTDIR)/bin
+install_hdrs_dir := $(INSTALLDIR)/include/$(project_name)
+install_libs_dir := $(INSTALLDIR)/lib/$(project_name)
+install_exes_dir := $(INSTALLDIR)/bin
 
 #-------------------------------------------------------------------------
 # List of subprojects


### PR DESCRIPTION
DESTDIR is a common make idiom.  As per the GNU coding standards

  https://www.gnu.org/prep/standards/html_node/DESTDIR.html

  "DESTDIR is a variable prepended to each installed target file, like
  this:

  $(INSTALL_PROGRAM) foo $(DESTDIR)$(bindir)/foo
  $(INSTALL_DATA) libfoo.a $(DESTDIR)$(libdir)/libfoo.a

  The DESTDIR variable is specified by the user on the make command
  line as an absolute file name. For example:

  make DESTDIR=/tmp/stage install

  DESTDIR should be supported only in the install* and uninstall*
  targets, as those are the only targets where it is useful.

  If your installation step would normally install /usr/local/bin/foo
  and /usr/local/lib/libfoo.a, then an installation invoked as in the
  example above would install /tmp/stage/usr/local/bin/foo and
  /tmp/stage/usr/local/lib/libfoo.a instead."

The current Makefile.in uses DESTDIR, but has a slightly non-standard
behavior: the target install location doesn't include "$prefix".  This
breaks package managers, because stuff ends up getting installed to
the wrong location.

Unfortunately the only way I can think of to fix this involves
silently changing the behavior of DESTDIR.  Hopefully nobody is using
it...?

[port of 8a2088b59162fe16c16d26ddc1cfcaaaa8c4156f in riscv-fesvr]