### PR TITLE
If atomics were disabled then emulate even in asm

### DIFF
--- a/pk/mentry.S
+++ b/pk/mentry.S
@@ -179,6 +179,9 @@ mentry:
   j init_first_hart
 
 .LmultiHart:
+#ifndef PK_ENABLE_ATOMICS
+  j .LmultiHart
+#else
   # make sure our hart id is within a valid range
   li a1, MAX_HARTS
   bgeu a0, a1, .LmultiHart
@@ -196,6 +199,7 @@ mentry:
   beqz sp, 1b
 
   j init_other_hart
+#endif
 
 .Linterrupt:
   sll a0, a0, 1    # discard MSB


### PR DESCRIPTION
There is one use of atomics in the assembly code for the pk. The other uses of atomics are in C and use this define to avoid calling using native atomics and instead emulate them. This commit emulates the assembly use of an atomic, non-atomically. This won't reliably work with multiple hearts but I don't think there is an easy way around that without atomics.
