### PR TITLE
initialize num_harts to 0 when query harts

### DIFF
--- a/machine/configstring.c
+++ b/machine/configstring.c
@@ -60,6 +60,7 @@ static void query_hart_plic(const char* config_string, hls_t* hls, int core, int
 
 static void query_harts(const char* config_string)
 {
+  num_harts = 0;
   for (int core = 0, hart; ; core++) {
     for (hart = 0; ; hart++) {
       char buf[32];


### PR DESCRIPTION
Seems num_harts is not initialized by anyone. It shows up a random value in my actual FPGA run but OK in simulation.