### PR TITLE
machine, emulation.c: fix the condition of rdtime emulation

### DIFF
--- a/machine/emulation.c
+++ b/machine/emulation.c
@@ -95,13 +95,13 @@ static inline int emulate_read_csr(int num, uintptr_t mstatus, uintptr_t* result
   switch (num)
   {
     case CSR_TIME:
-      if ((counteren >> (CSR_TIME - CSR_CYCLE)) & 1)
+      if (!((counteren >> (CSR_TIME - CSR_CYCLE)) & 1))
         return -1;
       *result = *mtime;
       return 0;
 #ifdef __riscv32
     case CSR_TIMEH:
-      if ((counteren >> (CSR_TIME - CSR_CYCLE)) & 1)
+      if (!((counteren >> (CSR_TIME - CSR_CYCLE)) & 1))
         return -1;
       *result = *mtime >> 32;
       return 0;


### PR DESCRIPTION
The time counter is enabled with the bit field set in `counteren` CSR.