### PR TITLE
machine, mentry.S: fix not receiving IPI for other harts

### DIFF
--- a/machine/mentry.S
+++ b/machine/mentry.S
@@ -232,6 +232,10 @@ do_reset:
 
   beqz a0, init_first_hart
 
+  # set MSIE bit to receive IPI
+  li a1, MIP_MSIP
+  csrw mie, a1
+
 .LmultiHart:
 #if MAX_HARTS > 1
   # wait for an IPI to signal that it's safe to boot


### PR DESCRIPTION
* Before waiting for IPI by executing wfi instruction, MSIE bit
  should be set in mie CSR for other harts, else they will get
  stuck at the wfi instruction.