### PR TITLE
Make sure pages for ELF sections have correct protection

### DIFF
--- a/pk/elf.h
+++ b/pk/elf.h
@@ -36,6 +36,10 @@
 #define AT_SECURE 23
 #define AT_RANDOM 25
 
+#define PF_X 1
+#define PF_W 2
+#define PF_R 4
+
 typedef struct {
   uint8_t  e_ident[16];
   uint16_t e_type;


### PR DESCRIPTION
I'm not sure whether this is necessary or not, but pk/bbl hasn't been correctly protecting the sections of the ELF it's loading. This could help debug some issues like code accidentally modifying the .rodata or .text sections or jumping outside of the .text section.