### PR TITLE
Elide a GCC warning

### DIFF
--- a/machine/configstring.c
+++ b/machine/configstring.c
@@ -36,7 +36,7 @@ static void query_plic(const char* config_string)
 
 static void query_hart_plic(const char* config_string, hls_t* hls, int core, int hart)
 {
-  char buf[32];
+  char buf[320];
   snprintf(buf, sizeof buf, "core{%d{%d{plic{m{ie", core, hart);
   query_result res = query_config_string(config_string, buf);
   if (res.start)
@@ -62,7 +62,7 @@ static void query_harts(const char* config_string)
 {
   for (int core = 0, hart; ; core++) {
     for (hart = 0; ; hart++) {
-      char buf[32];
+      char buf[320];
       snprintf(buf, sizeof buf, "core{%d{%d{ipi", core, hart);
       query_result res = query_config_string(config_string, buf);
       if (!res.start)


### PR DESCRIPTION
We're killing config string anyway, right?