### PR TITLE
Allow appending to LIBS when running make

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -93,7 +93,7 @@ COMPILE       := $(CC) -MMD -MP $(CFLAGS) \
 
 LD            := $(CC)
 LDFLAGS       := @LDFLAGS@ -nostartfiles -nostdlib -static $(LDFLAGS)
-LIBS          := @LIBS@
+LIBS          := @LIBS@ $(LIBS)
 LINK          := $(LD) $(LDFLAGS)
 
 # Library creation


### PR DESCRIPTION
Like `CFLAGS` and `LDFLAGS`, allow the user to append to `LIBS` when running `make`.

I have a usage case where I'm adding some system calls to the Proxy Kernel and I need to link against some other libraries. While I'm already modifying the Proxy Kernel with wrappers to the code for these systemcalls it would be nice if I can specify the library linkages on the command line without modifying the build flow.