### PR TITLE
Add a platform interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@
 
 build/
 autom4te.cache/
-
+*.swp
+*~

--- a/bbl/bbl.c
+++ b/bbl/bbl.c
@@ -5,6 +5,7 @@
 #include "bits.h"
 #include "config.h"
 #include "fdt.h"
+#include "platform_interface.h"
 #include <string.h>
 
 static const void* entry_point;
@@ -23,7 +24,7 @@ static void filter_dtb(uintptr_t source)
   memcpy((void*)dest, (void*)source, size);
 
   // Remove information from the chained FDT
-  filter_harts(dest, DISABLED_HART_MASK);
+  filter_harts(dest, platform__disabled_hart_mask);
   filter_plic(dest);
   filter_compat(dest, "riscv,clint0");
   filter_compat(dest, "riscv,debug-013");

--- a/bbl/bbl.mk.in
+++ b/bbl/bbl.mk.in
@@ -3,6 +3,7 @@ bbl_subproject_deps = \
   softfloat \
   machine \
   dummy_payload \
+  platform \
 
 bbl_hdrs = \
   bbl.h \

--- a/bbl/logo.c
+++ b/bbl/logo.c
@@ -1,32 +1,8 @@
 #include <string.h>
 #include "mtrap.h"
-
-static const char logo[] =
-"              vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv\n"
-"                  vvvvvvvvvvvvvvvvvvvvvvvvvvvv\n"
-"rrrrrrrrrrrrr       vvvvvvvvvvvvvvvvvvvvvvvvvv\n"
-"rrrrrrrrrrrrrrrr      vvvvvvvvvvvvvvvvvvvvvvvv\n"
-"rrrrrrrrrrrrrrrrrr    vvvvvvvvvvvvvvvvvvvvvvvv\n"
-"rrrrrrrrrrrrrrrrrr    vvvvvvvvvvvvvvvvvvvvvvvv\n"
-"rrrrrrrrrrrrrrrrrr    vvvvvvvvvvvvvvvvvvvvvvvv\n"
-"rrrrrrrrrrrrrrrr      vvvvvvvvvvvvvvvvvvvvvv  \n"
-"rrrrrrrrrrrrr       vvvvvvvvvvvvvvvvvvvvvv    \n"
-"rr                vvvvvvvvvvvvvvvvvvvvvv      \n"
-"rr            vvvvvvvvvvvvvvvvvvvvvvvv      rr\n"
-"rrrr      vvvvvvvvvvvvvvvvvvvvvvvvvv      rrrr\n"
-"rrrrrr      vvvvvvvvvvvvvvvvvvvvvv      rrrrrr\n"
-"rrrrrrrr      vvvvvvvvvvvvvvvvvv      rrrrrrrr\n"
-"rrrrrrrrrr      vvvvvvvvvvvvvv      rrrrrrrrrr\n"
-"rrrrrrrrrrrr      vvvvvvvvvv      rrrrrrrrrrrr\n"
-"rrrrrrrrrrrrrr      vvvvvv      rrrrrrrrrrrrrr\n"
-"rrrrrrrrrrrrrrrr      vv      rrrrrrrrrrrrrrrr\n"
-"rrrrrrrrrrrrrrrrrr          rrrrrrrrrrrrrrrrrr\n"
-"rrrrrrrrrrrrrrrrrrrr      rrrrrrrrrrrrrrrrrrrr\n"
-"rrrrrrrrrrrrrrrrrrrrrr  rrrrrrrrrrrrrrrrrrrrrr\n"
-"\n"
-"       INSTRUCTION SETS WANT TO BE FREE\n";
+#include "platform_interface.h"
 
 void print_logo()
 {
-  putstring(logo);
+  putstring(platform__get_logo());
 }

--- a/bbl/logo.c
+++ b/bbl/logo.c
@@ -4,5 +4,7 @@
 
 void print_logo()
 {
-  putstring(platform__get_logo());
+  const char *logo = platform__get_logo();
+  if (logo != NULL)
+    putstring(logo);
 }

--- a/config.h.in
+++ b/config.h.in
@@ -40,6 +40,9 @@
 #undef PK_ENABLE_VM
 
 /* Define if subproject MCPPBS_SPROJ_NORM is enabled */
+#undef PLATFORM_ENABLED
+
+/* Define if subproject MCPPBS_SPROJ_NORM is enabled */
 #undef SOFTFLOAT_ENABLED
 
 /* Define to 1 if you have the ANSI C header files. */

--- a/configure
+++ b/configure
@@ -4433,6 +4433,51 @@ $as_echo "#define UTIL_ENABLED /**/" >>confdefs.h
 
 
 
+    # Determine if this is a required or an optional subproject
+
+
+
+    # Determine if there is a group with the same name
+
+
+
+    # Create variations of the subproject name suitable for use as a CPP
+    # enabled define, a shell enabled variable, and a shell function
+
+
+
+
+
+
+
+
+
+
+
+    # Add subproject to our running list
+
+    subprojects="$subprojects platform"
+
+    # Process the subproject appropriately. If enabled add it to the
+    # $enabled_subprojects running shell variable, set a
+    # SUBPROJECT_ENABLED C define, and include the appropriate
+    # 'subproject.ac'.
+
+
+      { $as_echo "$as_me:${as_lineno-$LINENO}: configuring default subproject : platform" >&5
+$as_echo "$as_me: configuring default subproject : platform" >&6;}
+      ac_config_files="$ac_config_files platform.mk:platform/platform.mk.in"
+
+      enable_platform_sproj="yes"
+      subprojects_enabled="$subprojects_enabled platform"
+
+$as_echo "#define PLATFORM_ENABLED /**/" >>confdefs.h
+
+
+
+
+
+
   # Output make variables
 
 
@@ -5155,6 +5200,7 @@ do
     "dummy_payload.mk") CONFIG_FILES="$CONFIG_FILES dummy_payload.mk:dummy_payload/dummy_payload.mk.in" ;;
     "machine.mk") CONFIG_FILES="$CONFIG_FILES machine.mk:machine/machine.mk.in" ;;
     "util.mk") CONFIG_FILES="$CONFIG_FILES util.mk:util/util.mk.in" ;;
+    "platform.mk") CONFIG_FILES="$CONFIG_FILES platform.mk:platform/platform.mk.in" ;;
     "config.h") CONFIG_HEADERS="$CONFIG_HEADERS config.h" ;;
     "Makefile") CONFIG_FILES="$CONFIG_FILES Makefile" ;;
 

--- a/configure
+++ b/configure
@@ -592,6 +592,7 @@ subprojects_enabled
 subprojects
 BBL_PAYLOAD
 install_subdir
+PLATFORM_NAME
 RISCV
 EGREP
 GREP
@@ -669,6 +670,7 @@ ac_user_opts='
 enable_option_checking
 enable_stow
 enable_32bit
+with_platform
 enable_optional_subprojects
 enable_vm
 enable_logo
@@ -1325,6 +1327,7 @@ Optional Features:
 Optional Packages:
   --with-PACKAGE[=ARG]    use PACKAGE [ARG=yes]
   --without-PACKAGE       do not use PACKAGE (same as --with-PACKAGE=no)
+  --with-platform=spike   Select the target platform
   --with-payload          Set ELF payload for bbl
 
 Some influential environment variables:
@@ -4088,6 +4091,17 @@ case "${BUILD_32BIT}" in
 	install_subdir="riscv64-unknown-elf"
 	;;
 esac
+
+
+# Check whether --with-platform was given.
+if test "${with_platform+set}" = set; then :
+  withval=$with_platform; PLATFORM_NAME=$withval
+else
+  PLATFORM_NAME=spike
+fi
+
+PLATFORM_NAME=$PLATFORM_NAME
+
 
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -111,7 +111,7 @@ AC_SUBST(install_subdir)
 # The '*' suffix indicates an optional subproject. The '**' suffix
 # indicates an optional subproject which is also the name of a group.
 
-MCPPBS_SUBPROJECTS([ pk, bbl, softfloat, dummy_payload, machine, util ])
+MCPPBS_SUBPROJECTS([ pk, bbl, softfloat, dummy_payload, machine, util, platform ])
 
 #-------------------------------------------------------------------------
 # MCPPBS subproject groups

--- a/configure.ac
+++ b/configure.ac
@@ -99,6 +99,12 @@ case "${BUILD_32BIT}" in
 	;;
 esac
 
+AC_ARG_WITH([platform],
+	AS_HELP_STRING([--with-platform=spike], [Select the target platform]),
+	PLATFORM_NAME=$withval,
+	PLATFORM_NAME=spike)
+AC_SUBST(PLATFORM_NAME, $PLATFORM_NAME)
+
 AC_SUBST(CFLAGS)
 AC_SUBST(LDFLAGS)
 AC_SUBST([LIBS], ["-lgcc"])

--- a/machine/machine.mk.in
+++ b/machine/machine.mk.in
@@ -1,5 +1,6 @@
 machine_subproject_deps = \
   softfloat \
+  platform \
 
 machine_hdrs = \
   atomic.h \

--- a/machine/mentry.S
+++ b/machine/mentry.S
@@ -258,7 +258,11 @@ do_reset:
   add sp, sp, a2
 
   # Boot on the first unmasked hart
-  li a4, (~DISABLED_HART_MASK & (DISABLED_HART_MASK+1))
+  la a4, platform__disabled_hart_mask
+  LOAD a4, 0(a4)
+  addi a5, a4, 1
+  not a4, a4
+  and a4, a4, a5
   srl a4, a4, a3
   andi a4, a4, 1
   bnez a4, init_first_hart
@@ -273,7 +277,8 @@ do_reset:
   wfi
 
   # masked harts never start
-  li a4, DISABLED_HART_MASK
+  la a4, platform__disabled_hart_mask
+  LOAD a4, 0(a4)
   srl a4, a4, a3
   andi a4, a4, 1
   bnez a4, .LmultiHart

--- a/machine/minit.c
+++ b/machine/minit.c
@@ -4,6 +4,7 @@
 #include "fp_emulation.h"
 #include "fdt.h"
 #include "uart.h"
+#include "platform_interface.h"
 #include <string.h>
 #include <limits.h>
 
@@ -123,7 +124,7 @@ static void hart_plic_init()
 static void wake_harts()
 {
   for (int hart = 0; hart < MAX_HARTS; ++hart)
-    if ((((~DISABLED_HART_MASK & hart_mask) >> hart) & 1))
+    if ((((~platform__disabled_hart_mask & hart_mask) >> hart) & 1))
       *OTHER_HLS(hart)->ipi = 1; // wakeup the hart
 }
 

--- a/machine/mtrap.c
+++ b/machine/mtrap.c
@@ -7,6 +7,7 @@
 #include "uart.h"
 #include "fdt.h"
 #include "unprivileged_memory.h"
+#include "platform_interface.h"
 #include <errno.h>
 #include <stdarg.h>
 #include <stdio.h>
@@ -20,7 +21,7 @@ static uintptr_t mcall_console_putchar(uint8_t ch)
 {
   if (uart) {
     uart_putchar(ch);
-  } else {
+  } else if (platform__use_htif()) {
     htif_console_putchar(ch);
   }
   return 0;
@@ -28,7 +29,11 @@ static uintptr_t mcall_console_putchar(uint8_t ch)
 
 void poweroff()
 {
-  htif_poweroff();
+  if (platform__use_htif()) {
+    htif_poweroff();
+  } else {
+    while (1);
+  }
 }
 
 void putstring(const char* s)
@@ -61,8 +66,10 @@ static uintptr_t mcall_console_getchar()
 {
   if (uart) {
     return uart_getchar();
-  } else {
+  } else if (platform__use_htif()) {
     return htif_console_getchar();
+  } else {
+    return '\0';
   }
 }
 

--- a/machine/mtrap.c
+++ b/machine/mtrap.c
@@ -56,7 +56,7 @@ void printm(const char* s, ...)
 
 static void send_ipi(uintptr_t recipient, int event)
 {
-  if (((DISABLED_HART_MASK >> recipient) & 1)) return;
+  if (((platform__disabled_hart_mask >> recipient) & 1)) return;
   atomic_or(&OTHER_HLS(recipient)->mipi_pending, event);
   mb();
   *OTHER_HLS(recipient)->ipi = 1;

--- a/machine/mtrap.h
+++ b/machine/mtrap.h
@@ -9,11 +9,6 @@
 # define MAX_HARTS 1
 #endif
 
-// These harts will be prevented from booting beyond bbl
-#ifndef DISABLED_HART_MASK
-#define DISABLED_HART_MASK	0x0UL
-#endif
-
 #ifndef __ASSEMBLER__
 
 #include <stdint.h>

--- a/pk/pk.mk.in
+++ b/pk/pk.mk.in
@@ -1,4 +1,5 @@
 pk_subproject_deps = \
+	platform \
 	util \
 	softfloat \
 	machine \

--- a/platform/platform.mk.in
+++ b/platform/platform.mk.in
@@ -1,0 +1,9 @@
+platform_subproject_deps =
+
+platform_hdrs = \
+  platform_interface.h
+
+platform_c_srcs = \
+  spike.c
+
+platform_asm_srcs =

--- a/platform/platform.mk.in
+++ b/platform/platform.mk.in
@@ -4,6 +4,6 @@ platform_hdrs = \
   platform_interface.h
 
 platform_c_srcs = \
-  spike.c
+  @PLATFORM_NAME@.c
 
 platform_asm_srcs =

--- a/platform/platform_interface.h
+++ b/platform/platform_interface.h
@@ -11,4 +11,8 @@
  * had before.
  */
 
+/* Returns a pointer to what's expected to be a staticly allocated logo string.
+ * This will be printed when BBL boots. */
+const char *platform__get_logo(void);
+
 #endif

--- a/platform/platform_interface.h
+++ b/platform/platform_interface.h
@@ -1,6 +1,8 @@
 #ifndef PLATFORM__PLATFORM_H
 #define PLATFORM__PLATFORM_H
 
+#ifndef __ASSEMBLY__
+
 /* This interface is designed to allow BBL/PK to be portable to multiple target
  * platforms.  The current interface has been hacked up based on SiFive's fork
  * of pk that runs on our FPGA boards.  The idea here is that rather than
@@ -17,5 +19,11 @@ const char *platform__get_logo(void);
 
 /* Returns TRUE if it's valid to use the HTIF */
 int platform__use_htif(void);
+
+/* The harts that should be excluded from booting to the target program and
+ * should intsead be held in a loop. */
+extern long platform__disabled_hart_mask;
+
+#endif
 
 #endif

--- a/platform/platform_interface.h
+++ b/platform/platform_interface.h
@@ -1,0 +1,14 @@
+#ifndef PLATFORM__PLATFORM_H
+#define PLATFORM__PLATFORM_H
+
+/* This interface is designed to allow BBL/PK to be portable to multiple target
+ * platforms.  The current interface has been hacked up based on SiFive's fork
+ * of pk that runs on our FPGA boards.  The idea here is that rather than
+ * forking pk and touching things all over the tree, changes should be local to
+ * the target directory.
+ *
+ * This interface isn't meant to be stable or sane, just better than what we
+ * had before.
+ */
+
+#endif

--- a/platform/platform_interface.h
+++ b/platform/platform_interface.h
@@ -15,4 +15,7 @@
  * This will be printed when BBL boots. */
 const char *platform__get_logo(void);
 
+/* Returns TRUE if it's valid to use the HTIF */
+int platform__use_htif(void);
+
 #endif

--- a/platform/sifive-vc707-devkit.c
+++ b/platform/sifive-vc707-devkit.c
@@ -1,0 +1,41 @@
+#include "platform_interface.h"
+
+static const char logo[] =
+"\r\n"
+"                SIFIVE, INC.\r\n"
+"\r\n"
+"         5555555555555555555555555\r\n"
+"        5555                   5555\r\n"
+"       5555                     5555\r\n"
+"      5555                       5555\r\n"
+"     5555       5555555555555555555555\r\n"
+"    5555       555555555555555555555555\r\n"
+"   5555                             5555\r\n"
+"  5555                               5555\r\n"
+" 5555                                 5555\r\n"
+"5555555555555555555555555555          55555\r\n"
+" 55555           555555555           55555\r\n"
+"   55555           55555           55555\r\n"
+"     55555           5           55555\r\n"
+"       55555                   55555\r\n"
+"         55555               55555\r\n"
+"           55555           55555\r\n"
+"             55555       55555\r\n"
+"               55555   55555\r\n"
+"                 555555555\r\n"
+"                   55555\r\n"
+"                     5\r\n"
+"\r\n"
+"           SiFive RISC-V Coreplex\r\n";
+
+long platform__disabled_hart_mask = 0x1;
+
+const char *platform__get_logo(void)
+{
+  return logo;
+}
+
+int platform__use_htif(void)
+{
+  return 0;
+}

--- a/platform/spike.c
+++ b/platform/spike.c
@@ -25,6 +25,8 @@ static const char logo[] =
 "\n"
 "       INSTRUCTION SETS WANT TO BE FREE\n";
 
+long platform__disabled_hart_mask = 0;
+
 const char *platform__get_logo(void)
 {
   return logo;

--- a/platform/spike.c
+++ b/platform/spike.c
@@ -1,1 +1,32 @@
 #include "platform_interface.h"
+
+static const char logo[] =
+"              vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv\n"
+"                  vvvvvvvvvvvvvvvvvvvvvvvvvvvv\n"
+"rrrrrrrrrrrrr       vvvvvvvvvvvvvvvvvvvvvvvvvv\n"
+"rrrrrrrrrrrrrrrr      vvvvvvvvvvvvvvvvvvvvvvvv\n"
+"rrrrrrrrrrrrrrrrrr    vvvvvvvvvvvvvvvvvvvvvvvv\n"
+"rrrrrrrrrrrrrrrrrr    vvvvvvvvvvvvvvvvvvvvvvvv\n"
+"rrrrrrrrrrrrrrrrrr    vvvvvvvvvvvvvvvvvvvvvvvv\n"
+"rrrrrrrrrrrrrrrr      vvvvvvvvvvvvvvvvvvvvvv  \n"
+"rrrrrrrrrrrrr       vvvvvvvvvvvvvvvvvvvvvv    \n"
+"rr                vvvvvvvvvvvvvvvvvvvvvv      \n"
+"rr            vvvvvvvvvvvvvvvvvvvvvvvv      rr\n"
+"rrrr      vvvvvvvvvvvvvvvvvvvvvvvvvv      rrrr\n"
+"rrrrrr      vvvvvvvvvvvvvvvvvvvvvv      rrrrrr\n"
+"rrrrrrrr      vvvvvvvvvvvvvvvvvv      rrrrrrrr\n"
+"rrrrrrrrrr      vvvvvvvvvvvvvv      rrrrrrrrrr\n"
+"rrrrrrrrrrrr      vvvvvvvvvv      rrrrrrrrrrrr\n"
+"rrrrrrrrrrrrrr      vvvvvv      rrrrrrrrrrrrrr\n"
+"rrrrrrrrrrrrrrrr      vv      rrrrrrrrrrrrrrrr\n"
+"rrrrrrrrrrrrrrrrrr          rrrrrrrrrrrrrrrrrr\n"
+"rrrrrrrrrrrrrrrrrrrr      rrrrrrrrrrrrrrrrrrrr\n"
+"rrrrrrrrrrrrrrrrrrrrrr  rrrrrrrrrrrrrrrrrrrrrr\n"
+"\n"
+"       INSTRUCTION SETS WANT TO BE FREE\n";
+
+
+const char *platform__get_logo(void)
+{
+  return logo;
+}

--- a/platform/spike.c
+++ b/platform/spike.c
@@ -25,8 +25,12 @@ static const char logo[] =
 "\n"
 "       INSTRUCTION SETS WANT TO BE FREE\n";
 
-
 const char *platform__get_logo(void)
 {
   return logo;
+}
+
+int platform__use_htif(void)
+{
+  return 1;
 }

--- a/platform/spike.c
+++ b/platform/spike.c
@@ -1,0 +1,1 @@
+#include "platform_interface.h"


### PR DESCRIPTION
Right now we can't boot exactly the same BBL on spike and the FPGA.  We'd been maintaining a fork at http://github.com/sifive/riscv-pk, but this got very out of date.  In order to avoid maintain a fork I've decided to add a "platform" behind which these details live.  I'm hoping to kill this when the platform spec is good enough so I haven't done any actual work to design the interface, but for now I think it's good enough to avoid forking again.

This adds "--with-platform", a new autoconf switch, that lets users select the platform to target.  There's two right now: spike (the default) and sifive-vc707-devkit (which boots on our FPGA).