### PR TITLE
Add the '--enable-print-device-tree' argument

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -39,6 +39,9 @@
 /* Define if virtual memory support is enabled */
 #undef PK_ENABLE_VM
 
+/* Define if the DTS is to be displayed */
+#undef PK_PRINT_DEVICE_TREE
+
 /* Define if subproject MCPPBS_SPROJ_NORM is enabled */
 #undef PLATFORM_ENABLED
 

--- a/configure
+++ b/configure
@@ -671,6 +671,7 @@ enable_option_checking
 enable_stow
 enable_32bit
 with_platform
+enable_print_device_tree
 enable_optional_subprojects
 enable_vm
 enable_logo
@@ -1318,6 +1319,8 @@ Optional Features:
   --enable-FEATURE[=ARG]  include FEATURE [ARG=yes]
   --enable-stow           Enable stow-based install
   --enable-32bit          Build a 32-bit pk
+  --enable-print-device-tree
+                          Print DTS when booting
   --enable-optional-subprojects
                           Enable all optional subprojects
   --disable-vm            Disable virtual memory
@@ -4102,6 +4105,19 @@ fi
 
 PLATFORM_NAME=$PLATFORM_NAME
 
+
+# Check whether --enable-print-device-tree was given.
+if test "${enable_print_device_tree+set}" = set; then :
+  enableval=$enable_print_device_tree;
+fi
+
+if test "x$enable_print_device_tree" == "xyes"; then :
+
+
+$as_echo "#define PK_PRINT_DEVICE_TREE /**/" >>confdefs.h
+
+
+fi
 
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -105,6 +105,11 @@ AC_ARG_WITH([platform],
 	PLATFORM_NAME=spike)
 AC_SUBST(PLATFORM_NAME, $PLATFORM_NAME)
 
+AC_ARG_ENABLE([print-device-tree], AS_HELP_STRING([--enable-print-device-tree], [Print DTS when booting]))
+AS_IF([test "x$enable_print_device_tree" == "xyes"], [
+  AC_DEFINE([PK_PRINT_DEVICE_TREE],,[Define if the DTS is to be displayed])
+])
+
 AC_SUBST(CFLAGS)
 AC_SUBST(LDFLAGS)
 AC_SUBST([LIBS], ["-lgcc"])

--- a/machine/fdt.h
+++ b/machine/fdt.h
@@ -68,4 +68,9 @@ void filter_compat(uintptr_t fdt, const char *compat);
 // The hartids of available harts
 extern uint64_t hart_mask;
 
+#ifdef PK_PRINT_DEVICE_TREE
+// Prints the device tree to the console as a DTS
+void fdt_print(uintptr_t fdt);
+#endif
+
 #endif

--- a/machine/mtrap.c
+++ b/machine/mtrap.c
@@ -42,16 +42,20 @@ void putstring(const char* s)
     mcall_console_putchar(*s++);
 }
 
-void printm(const char* s, ...)
+void vprintm(const char* s, va_list vl)
 {
   char buf[256];
+  vsnprintf(buf, sizeof buf, s, vl);
+  putstring(buf);
+}
+
+void printm(const char* s, ...)
+{
   va_list vl;
 
   va_start(vl, s);
-  vsnprintf(buf, sizeof buf, s, vl);
+  vprintm(s, vl);
   va_end(vl);
-
-  putstring(buf);
 }
 
 static void send_ipi(uintptr_t recipient, int event)

--- a/machine/mtrap.h
+++ b/machine/mtrap.h
@@ -13,6 +13,7 @@
 
 #include <stdint.h>
 #include <stddef.h>
+#include <stdarg.h>
 
 #define read_const_csr(reg) ({ unsigned long __tmp; \
   asm ("csrr %0, " #reg : "=r"(__tmp)); \
@@ -57,6 +58,7 @@ hls_t* hls_init(uintptr_t hart_id);
 void parse_config_string();
 void poweroff(void) __attribute((noreturn));
 void printm(const char* s, ...);
+void vprintm(const char *s, va_list args);
 void putstring(const char* s);
 #define assert(x) ({ if (!(x)) die("assertion failed: %s", #x); })
 #define die(str, ...) ({ printm("%s:%d: " str "\n", __FILE__, __LINE__, ##__VA_ARGS__); poweroff(); })


### PR DESCRIPTION
I'm trying to debug some device tree problems while booting Linux and
figured it would be really nice to have access to the device tree while
trying to debug these problems.  I think this might be useful for lots
of people, so I went ahead and cleaned up the code enough that it should
actaully work in most cases.