### PR TITLE
Allow platforms to limit the physical memory size

### DIFF
--- a/bbl/bbl.c
+++ b/bbl/bbl.c
@@ -28,6 +28,8 @@ static void filter_dtb(uintptr_t source)
   filter_plic(dest);
   filter_compat(dest, "riscv,clint0");
   filter_compat(dest, "riscv,debug-013");
+  if (platform__limit_memory_bytes > 0)
+    fdt_reduce_mem(dest, platform__limit_memory_bytes);
 }
 
 void boot_other_hart(uintptr_t unused __attribute__((unused)))

--- a/machine/fdt.h
+++ b/machine/fdt.h
@@ -65,6 +65,9 @@ void filter_harts(uintptr_t fdt, unsigned long hart_mask);
 void filter_plic(uintptr_t fdt);
 void filter_compat(uintptr_t fdt, const char *compat);
 
+// Limit the memory in the FDT to N bytes. */
+void fdt_reduce_mem(uintptr_t fdt, unsigned long bytes);
+
 // The hartids of available harts
 extern uint64_t hart_mask;
 

--- a/platform/platform_interface.h
+++ b/platform/platform_interface.h
@@ -24,6 +24,9 @@ int platform__use_htif(void);
  * should intsead be held in a loop. */
 extern long platform__disabled_hart_mask;
 
+/* The number of bytes of memory this platform can actually support. */
+extern long platform__limit_memory_bytes;
+
 #endif
 
 #endif

--- a/platform/sifive-vc707-devkit.c
+++ b/platform/sifive-vc707-devkit.c
@@ -29,6 +29,7 @@ static const char logo[] =
 "           SiFive RISC-V Coreplex\r\n";
 
 long platform__disabled_hart_mask = 0x1;
+long platform__limit_memory_bytes = 2UL * 1024 * 1024 * 1024;
 
 const char *platform__get_logo(void)
 {

--- a/platform/spike.c
+++ b/platform/spike.c
@@ -26,6 +26,7 @@ static const char logo[] =
 "       INSTRUCTION SETS WANT TO BE FREE\n";
 
 long platform__disabled_hart_mask = 0;
+long platform__limit_memory_bytes = 0;
 
 const char *platform__get_logo(void)
 {


### PR DESCRIPTION
The DMA controllor on the VC707 only supports 32-bit physical addresses.
Since we don't have an IOMMU or DMA regions in our Linux port, we need a
mechanism for limiting the amount of physical memory that Linux sees.
Since we map the memory to 2GB physical, we can only address 2GB of
DRAM.

Like everything in platform/, this is a hack.  This one we won't replace
with a DTS parser, we'll actually entirely remove it from BBL and
replace it with support for small DMA regions in our Linux port.