### PR TITLE
Detect harts that can't boot Linux instead of hard-coding them

### DIFF
--- a/machine/disabled_hart_mask.h
+++ b/machine/disabled_hart_mask.h
@@ -1,0 +1,4 @@
+#ifndef DISABLED_HART_MASK_H
+#define DISABLED_HART_MASK_H
+extern long disabled_hart_mask;
+#endif

--- a/machine/fdt.h
+++ b/machine/fdt.h
@@ -61,7 +61,7 @@ void query_plic(uintptr_t fdt);
 void query_clint(uintptr_t fdt);
 
 // Remove information from FDT
-void filter_harts(uintptr_t fdt, unsigned long hart_mask);
+void filter_harts(uintptr_t fdt, long *disabled_hart_mask);
 void filter_plic(uintptr_t fdt);
 void filter_compat(uintptr_t fdt, const char *compat);
 

--- a/machine/mentry.S
+++ b/machine/mentry.S
@@ -258,7 +258,7 @@ do_reset:
   add sp, sp, a2
 
   # Boot on the first unmasked hart
-  la a4, platform__disabled_hart_mask
+  la a4, disabled_hart_mask
   LOAD a4, 0(a4)
   addi a5, a4, 1
   not a4, a4
@@ -277,7 +277,7 @@ do_reset:
   wfi
 
   # masked harts never start
-  la a4, platform__disabled_hart_mask
+  la a4, disabled_hart_mask
   LOAD a4, 0(a4)
   srl a4, a4, a3
   andi a4, a4, 1

--- a/machine/minit.c
+++ b/machine/minit.c
@@ -132,11 +132,11 @@ static void wake_harts()
 
 void init_first_hart(uintptr_t hartid, uintptr_t dtb)
 {
-  hart_init();
-  hls_init(0); // this might get called again from parse_config_string
-
   // Confirm console as early as possible
   query_uart(dtb);
+
+  hart_init();
+  hls_init(0); // this might get called again from parse_config_string
 
   // Find the power button early as well so die() works
   query_finisher(dtb);

--- a/machine/minit.c
+++ b/machine/minit.c
@@ -6,6 +6,7 @@
 #include "uart.h"
 #include "finisher.h"
 #include "platform_interface.h"
+#include "disabled_hart_mask.h"
 #include <string.h>
 #include <limits.h>
 
@@ -125,7 +126,7 @@ static void hart_plic_init()
 static void wake_harts()
 {
   for (int hart = 0; hart < MAX_HARTS; ++hart)
-    if ((((~platform__disabled_hart_mask & hart_mask) >> hart) & 1))
+    if ((((~disabled_hart_mask & hart_mask) >> hart) & 1))
       *OTHER_HLS(hart)->ipi = 1; // wakeup the hart
 }
 

--- a/machine/mtrap.c
+++ b/machine/mtrap.c
@@ -9,6 +9,7 @@
 #include "fdt.h"
 #include "unprivileged_memory.h"
 #include "platform_interface.h"
+#include "disabled_hart_mask.h"
 #include <errno.h>
 #include <stdarg.h>
 #include <stdio.h>
@@ -63,7 +64,7 @@ void printm(const char* s, ...)
 
 static void send_ipi(uintptr_t recipient, int event)
 {
-  if (((platform__disabled_hart_mask >> recipient) & 1)) return;
+  if (((disabled_hart_mask >> recipient) & 1)) return;
   atomic_or(&OTHER_HLS(recipient)->mipi_pending, event);
   mb();
   *OTHER_HLS(recipient)->ipi = 1;

--- a/pk/pk.c
+++ b/pk/pk.c
@@ -7,6 +7,7 @@
 #include <stdbool.h>
 
 elf_info current;
+long disabled_hart_mask;
 
 static void handle_option(const char* s)
 {

--- a/platform/platform_interface.h
+++ b/platform/platform_interface.h
@@ -20,10 +20,6 @@ const char *platform__get_logo(void);
 /* Returns TRUE if it's valid to use the HTIF */
 int platform__use_htif(void);
 
-/* The harts that should be excluded from booting to the target program and
- * should intsead be held in a loop. */
-extern long platform__disabled_hart_mask;
-
 #endif
 
 #endif

--- a/platform/sifive-vc707-devkit.c
+++ b/platform/sifive-vc707-devkit.c
@@ -28,8 +28,6 @@ static const char logo[] =
 "\r\n"
 "           SiFive RISC-V Coreplex\r\n";
 
-long platform__disabled_hart_mask = 0x1;
-
 const char *platform__get_logo(void)
 {
   return logo;

--- a/platform/spike.c
+++ b/platform/spike.c
@@ -25,8 +25,6 @@ static const char logo[] =
 "\n"
 "       INSTRUCTION SETS WANT TO BE FREE\n";
 
-long platform__disabled_hart_mask = 0;
-
 const char *platform__get_logo(void)
 {
   return logo;


### PR DESCRIPTION
This checks to see if a hart can't boot Linux by looking for a
compatible "mmu-type" field.  If the hart can't boot Linux, then bbl
masks it off.