### PR TITLE
Un-break "--enable-32bit"

### DIFF
--- a/configure
+++ b/configure
@@ -4084,13 +4084,13 @@ fi
 case "${BUILD_32BIT}" in
   yes|default)
 	echo "Building 32-bit pk"
-	CFLAGS="$default_CFLAGS -m32"
-	LDFLAGS="-m32"
+	CFLAGS="$default_CFLAGS -march=rv32imafdc -mabi=ilp32d"
+	LDFLAGS="-march=rv32imafdc -mabi=ilp32d"
 	install_subdir="riscv32-unknown-elf"
 	;;
   *)
-	CFLAGS="$default_CFLAGS"
-	LDFLAGS=
+	CFLAGS="$default_CFLAGS -march=rv64imafdc -mabi=lp64d"
+	LDFLAGS="-march=rv64imafdc -mabi=lp64d"
 	install_subdir="riscv64-unknown-elf"
 	;;
 esac

--- a/configure.ac
+++ b/configure.ac
@@ -88,13 +88,13 @@ AC_ARG_ENABLE([32bit],
 case "${BUILD_32BIT}" in
   yes|default)
 	echo "Building 32-bit pk"
-	CFLAGS="$default_CFLAGS -m32"
-	LDFLAGS="-m32"
+	CFLAGS="$default_CFLAGS -march=rv32imafdc -mabi=ilp32d"
+	LDFLAGS="-march=rv32imafdc -mabi=ilp32d"
 	install_subdir="riscv32-unknown-elf"
 	;;
   *)
-	CFLAGS="$default_CFLAGS"
-	LDFLAGS=
+	CFLAGS="$default_CFLAGS -march=rv64imafdc -mabi=lp64d"
+	LDFLAGS="-march=rv64imafdc -mabi=lp64d"
 	install_subdir="riscv64-unknown-elf"
 	;;
 esac


### PR DESCRIPTION
We had the wrong set of compiler options for 32-bit builds, "-m32"
hasn't been supported in a while.

This should fix https://github.com/riscv/riscv-gnu-toolchain/issues/294