### PR TITLE
Boot on the first hart

### DIFF
--- a/machine/mentry.S
+++ b/machine/mentry.S
@@ -257,15 +257,8 @@ do_reset:
   slli a2, a3, RISCV_PGSHIFT
   add sp, sp, a2
 
-  # Boot on the first unmasked hart
-  la a4, disabled_hart_mask
-  LOAD a4, 0(a4)
-  addi a5, a4, 1
-  not a4, a4
-  and a4, a4, a5
-  srl a4, a4, a3
-  andi a4, a4, 1
-  bnez a4, init_first_hart
+  # Boot on the first hart
+  beqz a3, init_first_hart
 
   # set MSIE bit to receive IPI
   li a2, MIP_MSIP


### PR DESCRIPTION
This code is broken, and it's left over from before we could read the
DTB to find harts to boot on.