### PR TITLE
mtrap: loop forever, really

### DIFF
--- a/machine/mtrap.c
+++ b/machine/mtrap.c
@@ -38,7 +38,7 @@ void poweroff(uint16_t code)
   if (htif) {
     htif_poweroff();
   } else {
-    while (1);
+    while (1) { asm volatile ("#noop\n"); }
   }
 }
 


### PR DESCRIPTION
gcc sometimes takes liberties with optimizing away our important halt function!