### PR TITLE
32-bit HTIF Fix: TOHOST_CMD command word is 64-bit on both rv32 and rv64

### DIFF
--- a/machine/htif.h
+++ b/machine/htif.h
@@ -3,14 +3,9 @@
 
 #include <stdint.h>
 
-#if __riscv_xlen == 64
 # define TOHOST_CMD(dev, cmd, payload) \
   (((uint64_t)(dev) << 56) | ((uint64_t)(cmd) << 48) | (uint64_t)(payload))
-#else
-# define TOHOST_CMD(dev, cmd, payload) ({ \
-  if ((dev) || (cmd)) __builtin_trap(); \
-  (payload); })
-#endif
+
 #define FROMHOST_DEV(fromhost_value) ((uint64_t)(fromhost_value) >> 56)
 #define FROMHOST_CMD(fromhost_value) ((uint64_t)(fromhost_value) << 8 >> 56)
 #define FROMHOST_DATA(fromhost_value) ((uint64_t)(fromhost_value) << 16 >> 16)


### PR DESCRIPTION
That's a pending fix that I had to do to be able to run 32-bit versions of RTEMS and seL4. 

Not quite sure that's the right fix to do though