### PR TITLE
Allow 32-bit HTIF because it works on qemu-system-riscv32

### DIFF
--- a/machine/htif.h
+++ b/machine/htif.h
@@ -3,14 +3,9 @@
 
 #include <stdint.h>
 
-#if __riscv_xlen == 64
-# define TOHOST_CMD(dev, cmd, payload) \
+/* Caveat: HTIF on rv32 is not officially supported. Use at your own risk */
+#define TOHOST_CMD(dev, cmd, payload) \
   (((uint64_t)(dev) << 56) | ((uint64_t)(cmd) << 48) | (uint64_t)(payload))
-#else
-# define TOHOST_CMD(dev, cmd, payload) ({ \
-  if ((dev) || (cmd)) __builtin_trap(); \
-  (payload); })
-#endif
 #define FROMHOST_DEV(fromhost_value) ((uint64_t)(fromhost_value) >> 56)
 #define FROMHOST_CMD(fromhost_value) ((uint64_t)(fromhost_value) << 8 >> 56)
 #define FROMHOST_DATA(fromhost_value) ((uint64_t)(fromhost_value) << 16 >> 16)


### PR DESCRIPTION
To enable testing of rv32 riscv-linux on qemu-system-riscv32
it would be good if we had working HTIF in bbl. This change
has been tested using riscv-probe in spike and qemu:

- https://github.com/michaeljclark/riscv-probe

While there are compiler issues that could re-order 64-bit
loads and stores, and there is no official HTIF over 32-bit
protocol, or 64-bit HTIF with ordered loads/stores and fences;
however, given that it works as it is, it should be safe to
re-enable 32-bit support with a caveat.

Signed-off: mjc@sifive.com