### PR TITLE
mtrap: add a halt IPI used for poweroff

### DIFF
--- a/machine/mentry.S
+++ b/machine/mentry.S
@@ -91,6 +91,11 @@ trap_vector:
   beqz a1, 1f
   sfence.vma
 1:
+  andi a1, a0, IPI_HALT
+  beqz a1, 1f
+  wfi
+  j 1b
+1:
   j .Lmret
 
 

--- a/machine/mtrap.c
+++ b/machine/mtrap.c
@@ -31,17 +31,6 @@ static uintptr_t mcall_console_putchar(uint8_t ch)
   return 0;
 }
 
-void poweroff(uint16_t code)
-{
-  printm("Power off\n");
-  finisher_exit(code);
-  if (htif) {
-    htif_poweroff();
-  } else {
-    while (1) { asm volatile ("#noop\n"); }
-  }
-}
-
 void putstring(const char* s)
 {
   while (*s)
@@ -227,5 +216,17 @@ void trap_from_machine_mode(uintptr_t* regs, uintptr_t dummy, uintptr_t mepc)
       return machine_page_fault(regs, dummy, mepc);
     default:
       bad_trap(regs, dummy, mepc);
+  }
+}
+
+void poweroff(uint16_t code)
+{
+  printm("Power off\r\n");
+  finisher_exit(code);
+  if (htif) {
+    htif_poweroff();
+  } else {
+    send_ipi_many(0, IPI_HALT);
+    while (1) { asm volatile ("wfi\n"); }
   }
 }

--- a/machine/mtrap.h
+++ b/machine/mtrap.h
@@ -78,6 +78,7 @@ static inline void wfi()
 #define IPI_SOFT       0x1
 #define IPI_FENCE_I    0x2
 #define IPI_SFENCE_VMA 0x4
+#define IPI_HALT       0x8
 
 #define MACHINE_STACK_SIZE RISCV_PGSIZE
 #define MENTRY_HLS_OFFSET (INTEGER_CONTEXT_SIZE + SOFT_FLOAT_CONTEXT_SIZE)


### PR DESCRIPTION
Otherwise, linux complains the moment an interrupt arrives and
wakes up one of the not-looping cores.

I'm not sure adding a new IPI code is allowed. Is it?