### PR TITLE
Changed install_subdir to $host_alias with substituted 64->32 instead…

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ By default, 64-bit (RV64) versions of `pk` and `bbl` are built.  To
 built 32-bit (RV32) versions, supply a `--enable-32bit` flag to the
 configure command.
 
-The `install` step installs 64-bit build products into
-`$RISCV/riscv64-unknown-elf`, and 32-bit versions into
-`$RISCV/riscv32-unknown-elf`.
+The `install` step installs 64-bit build products into a directory
+matching your host (e.g. `$RISCV/riscv64-unknown-elf`). 32-bit versions 
+are installed into a directory matching a 32-bit version of your host (e.g.
+`$RISCV/riscv32-unknown-elf`).

--- a/configure
+++ b/configure
@@ -4086,12 +4086,13 @@ case "${BUILD_32BIT}" in
 	echo "Building 32-bit pk"
 	CFLAGS="$default_CFLAGS -m32"
 	LDFLAGS="-m32"
-	install_subdir="riscv32-unknown-elf"
+	install_subdir="`echo $host_alias | sed -e 's/64/32/g'`"
 	;;
   *)
 	CFLAGS="$default_CFLAGS"
 	LDFLAGS=
-	install_subdir="riscv64-unknown-elf"
+	install_subdir=$host_alias
+
 	;;
 esac
 

--- a/configure.ac
+++ b/configure.ac
@@ -90,12 +90,12 @@ case "${BUILD_32BIT}" in
 	echo "Building 32-bit pk"
 	CFLAGS="$default_CFLAGS -m32"
 	LDFLAGS="-m32"
-	install_subdir="riscv32-unknown-elf"
+  install_subdir="`echo $host_alias | sed -e 's/64/32/g'`"
 	;;
   *)
 	CFLAGS="$default_CFLAGS"
 	LDFLAGS=
-	install_subdir="riscv64-unknown-elf"
+	install_subdir=$host_alias
 	;;
 esac
 

--- a/configure.ac
+++ b/configure.ac
@@ -90,7 +90,7 @@ case "${BUILD_32BIT}" in
 	echo "Building 32-bit pk"
 	CFLAGS="$default_CFLAGS -m32"
 	LDFLAGS="-m32"
-  install_subdir="`echo $host_alias | sed -e 's/64/32/g'`"
+	install_subdir="`echo $host_alias | sed -e 's/64/32/g'`"
 	;;
   *)
 	CFLAGS="$default_CFLAGS"


### PR DESCRIPTION
Changed install_subdir to $host_alias with substituted 64->32 instead of hardcoded riscv[32|64]-unknown-elf

This is to allow other compilers like riscv64-VENDOR-OS ... and not just unknown-elf