### PR TITLE
Fix build with compilers defaulting to PIE

### DIFF
--- a/configure
+++ b/configure
@@ -4071,7 +4071,7 @@ fi
 # Set compiler flags
 #-------------------------------------------------------------------------
 
-default_CFLAGS="-Wall -Werror -D__NO_INLINE__ -mcmodel=medany -O2 -std=gnu99 -Wno-unused -Wno-attributes -fno-delete-null-pointer-checks"
+default_CFLAGS="-Wall -Werror -D__NO_INLINE__ -mcmodel=medany -O2 -std=gnu99 -Wno-unused -Wno-attributes -fno-delete-null-pointer-checks -fno-PIE"
 
 # Check whether --enable-32bit was given.
 if test "${enable_32bit+set}" = set; then :

--- a/configure.ac
+++ b/configure.ac
@@ -78,7 +78,7 @@ AC_ARG_VAR(RISCV, [top-level RISC-V install directory])
 # Set compiler flags
 #-------------------------------------------------------------------------
 
-default_CFLAGS="-Wall -Werror -D__NO_INLINE__ -mcmodel=medany -O2 -std=gnu99 -Wno-unused -Wno-attributes -fno-delete-null-pointer-checks"
+default_CFLAGS="-Wall -Werror -D__NO_INLINE__ -mcmodel=medany -O2 -std=gnu99 -Wno-unused -Wno-attributes -fno-delete-null-pointer-checks -fno-PIE"
 
 AC_ARG_ENABLE([32bit],
 	AS_HELP_STRING([--enable-32bit], [Build a 32-bit pk]),


### PR DESCRIPTION
Debian toolchain defaults to PIE, and I guess that will also be the case
of most distributions. This cause bbl to be non-functional.

This patch fixes that by adding -fno-PIE in the default CFLAGS.