### PR TITLE
Include .bss section to the binary so dtb_output() gets full size of payload

### DIFF
--- a/bbl/bbl.mk.in
+++ b/bbl/bbl.mk.in
@@ -17,7 +17,7 @@ bbl_asm_srcs = \
 payload.o: bbl_payload
 
 bbl_payload: $(BBL_PAYLOAD)
-	if $(READELF) -h $< 2> /dev/null > /dev/null; then $(OBJCOPY) -O binary $< $@; else cp $< $@; fi
+	if $(READELF) -h $< 2> /dev/null > /dev/null; then $(OBJCOPY) -O binary --set-section-flags .bss=alloc,load,contents $< $@; else cp $< $@; fi
 
 raw_logo.o: bbl_logo_file
 


### PR DESCRIPTION
dtb_output() does not include BSS section to calculations, in result it places DTB on top of bss.

Another solution would be to move dtbp to start of physical memory (0x80000000) or reserve more space in dtb_output() after payload.