### PR TITLE
Remove --enable-32bit in favour of --with-arch and --with-abi

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,18 +24,18 @@ directory is not supported; you need to use a separate build directory.
 
     $ mkdir build
     $ cd build
-    $ ../configure --prefix=$RISCV --host=riscv64-unknown-elf
+    $ ../configure --prefix=$RISCV --host=riscv64-unknown-elf \
+                   --with-arch=rv64imafd \
+                   --with-abi=lp64d
     $ make
     $ make install
 
-Alternatively, the GNU/Linux toolchain may be used to build this package,
-by setting `--host=riscv64-unknown-linux-gnu`.
-
-By default, 64-bit (RV64) versions of `pk` and `bbl` are built.  To
-built 32-bit (RV32) versions, supply a `--enable-32bit` flag to the
-configure command.
+Alternatively, the GNU/Linux toolchain may be used to build this package, by
+setting `--host=riscv64-unknown-linux-gnu`. The `--with-arch` and `--with-abi`
+flags are optional and can be used to specify an ISA and ABI other than the
+default for the host toolchain.
 
 The `install` step installs 64-bit build products into a directory
-matching your host (e.g. `$RISCV/riscv64-unknown-elf`). 32-bit versions 
+matching your host (e.g. `$RISCV/riscv64-unknown-elf`). 32-bit versions
 are installed into a directory matching a 32-bit version of your host (e.g.
 `$RISCV/riscv32-unknown-elf`).

--- a/configure
+++ b/configure
@@ -669,7 +669,8 @@ ac_subst_files=''
 ac_user_opts='
 enable_option_checking
 enable_stow
-enable_32bit
+with_arch
+with_abi
 enable_print_device_tree
 enable_optional_subprojects
 enable_vm
@@ -1318,7 +1319,6 @@ Optional Features:
   --disable-FEATURE       do not include FEATURE (same as --enable-FEATURE=no)
   --enable-FEATURE[=ARG]  include FEATURE [ARG=yes]
   --enable-stow           Enable stow-based install
-  --enable-32bit          Build a 32-bit pk
   --enable-print-device-tree
                           Print DTS when booting
   --enable-optional-subprojects
@@ -1330,6 +1330,9 @@ Optional Features:
 Optional Packages:
   --with-PACKAGE[=ARG]    use PACKAGE [ARG=yes]
   --without-PACKAGE       do not use PACKAGE (same as --with-PACKAGE=no)
+  --with-arch             Specify ISA string
+  --with-abi              Specify integer and floating-point calling
+                          convention
   --with-payload          Set ELF payload for bbl
   --with-logo             Specify a better logo
 
@@ -4071,32 +4074,49 @@ fi
 # Set compiler flags
 #-------------------------------------------------------------------------
 
-default_CFLAGS="-Wall -Werror -D__NO_INLINE__ -mcmodel=medany -O2 -std=gnu99 -Wno-unused -Wno-attributes -fno-delete-null-pointer-checks -fno-PIE"
+CFLAGS="-Wall -Werror -D__NO_INLINE__ -mcmodel=medany -O2 -std=gnu99 -Wno-unused -Wno-attributes -fno-delete-null-pointer-checks -fno-PIE"
+LDFLAGS="-Wl,--build-id=none"
 
-# Check whether --enable-32bit was given.
-if test "${enable_32bit+set}" = set; then :
-  enableval=$enable_32bit; BUILD_32BIT=$enableval
-else
-  BUILD_32BIT=no
+
+# Check whether --with-arch was given.
+if test "${with_arch+set}" = set; then :
+  withval=$with_arch;
 fi
 
 
-case "${BUILD_32BIT}" in
-  yes|default)
-	echo "Building 32-bit pk"
-	CFLAGS="$default_CFLAGS -m32"
-	LDFLAGS="-m32"
-	install_subdir="`echo $host_alias | sed -e 's/64/32/g'`"
-	;;
+# Check whether --with-abi was given.
+if test "${with_abi+set}" = set; then :
+  withval=$with_abi;
+fi
+
+
+FORCE_32BIT=no
+if test "x$with_arch" != x; then
+  CFLAGS="$CFLAGS -march=$with_arch"
+  case "$with_arch" in
+    rv32*)
+        FORCE_32BIT=yes
+        ;;
+    *)
+        ;;
+  esac
+fi
+
+if test "x$with_abi" != x; then
+  CFLAGS="$CFLAGS -mabi=$with_abi"
+fi
+
+case "${FORCE_32BIT}" in
+  yes)
+      # When building 32-bit pk and host=riscv64-*, host_alias would have an
+      # incorrect xlen for use as the install_subdir
+      echo "Forcing 32-bit install location"
+      install_subdir="`echo $host_alias | sed -e 's/64/32/g'`"
+      ;;
   *)
-	CFLAGS="$default_CFLAGS"
-	LDFLAGS=
-	install_subdir=$host_alias
-
-	;;
+      install_subdir=$host_alias
+      ;;
 esac
-
-LDFLAGS="$LDFLAGS -Wl,--build-id=none"
 
 # Check whether --enable-print-device-tree was given.
 if test "${enable_print_device_tree+set}" = set; then :

--- a/configure.ac
+++ b/configure.ac
@@ -78,28 +78,41 @@ AC_ARG_VAR(RISCV, [top-level RISC-V install directory])
 # Set compiler flags
 #-------------------------------------------------------------------------
 
-default_CFLAGS="-Wall -Werror -D__NO_INLINE__ -mcmodel=medany -O2 -std=gnu99 -Wno-unused -Wno-attributes -fno-delete-null-pointer-checks -fno-PIE"
+CFLAGS="-Wall -Werror -D__NO_INLINE__ -mcmodel=medany -O2 -std=gnu99 -Wno-unused -Wno-attributes -fno-delete-null-pointer-checks -fno-PIE"
+LDFLAGS="-Wl,--build-id=none"
 
-AC_ARG_ENABLE([32bit],
-	AS_HELP_STRING([--enable-32bit], [Build a 32-bit pk]),
-	BUILD_32BIT=$enableval,
-	BUILD_32BIT=no)
+AC_ARG_WITH([arch],
+  AS_HELP_STRING([--with-arch], [Specify ISA string]))
+AC_ARG_WITH([abi],
+  AS_HELP_STRING([--with-abi], [Specify integer and floating-point calling convention]))
 
-case "${BUILD_32BIT}" in
-  yes|default)
-	echo "Building 32-bit pk"
-	CFLAGS="$default_CFLAGS -m32"
-	LDFLAGS="-m32"
-	install_subdir="`echo $host_alias | sed -e 's/64/32/g'`"
-	;;
+FORCE_32BIT=no
+if test "x$with_arch" != x; then
+  CFLAGS="$CFLAGS -march=$with_arch"
+  case "$with_arch" in
+    rv32*)
+        FORCE_32BIT=yes
+        ;;
+    *)
+        ;;
+  esac
+fi
+
+if test "x$with_abi" != x; then
+  CFLAGS="$CFLAGS -mabi=$with_abi"
+fi
+
+case "${FORCE_32BIT}" in
+  yes)
+      # When building 32-bit pk and host=riscv64-*, host_alias would have an
+      # incorrect xlen for use as the install_subdir
+      echo "Forcing 32-bit install location"
+      install_subdir="`echo $host_alias | sed -e 's/64/32/g'`"
+      ;;
   *)
-	CFLAGS="$default_CFLAGS"
-	LDFLAGS=
-	install_subdir=$host_alias
-	;;
+      install_subdir=$host_alias
+      ;;
 esac
-
-LDFLAGS="$LDFLAGS -Wl,--build-id=none"
 
 AC_ARG_ENABLE([print-device-tree], AS_HELP_STRING([--enable-print-device-tree], [Print DTS when booting]))
 AS_IF([test "x$enable_print_device_tree" == "xyes"], [


### PR DESCRIPTION
Noting that a previous PR to fix the `--enable-32bit` flag (https://github.com/riscv/riscv-pk/pull/70) does un-break `--enable-32bit` but always configures for specific ISA strings and ABIs (mentioned in https://github.com/riscv/riscv-gnu-toolchain/issues/294), this PR fixes building for 32-bit by removing `--enable-32bit` entirely and instead adding `--with-arch` and `--with-abi` with the "usual" meanings.

I've tried this with various combinations, some of which are:

* `riscv64-unknown-elf` as host and `--with-arch=rv32im` (forces 32-bit install location)
* `riscv64-unknown-elf` as host, no arch or abi flags
* `riscv32-unknown-elf` as host (uses 32-bit install location, but not forced)
* `riscv32-unknown-elf` as host, 32-bit arch and abi flags specified
* `riscv64-unknown-elf` as host, 64-bit arch and abi flasg specified
* etc..

All these combinations (and some others not listed) appeared to do the right thing. I have been testing with the commit https://github.com/riscv/riscv-pk/commit/5a0e3e55cab1d6f3462c77e852f16365c79f2c98 reverted, as it appears to break 32-bit: https://github.com/riscv/riscv-pk/issues/92 - however, I don't believe there's any relation between this PR and that commit. I'm not quite sure what the fix for #92 on rv32 is yet.