### PR TITLE
Don't printm on rv32

### DIFF
--- a/machine/minit.c
+++ b/machine/minit.c
@@ -143,7 +143,12 @@ void init_first_hart(uintptr_t hartid, uintptr_t dtb)
   query_uart(dtb);
   query_uart16550(dtb);
   query_htif(dtb);
+
+  // This is a workaround for a race condition. Presently printm does not work
+  // on rv32 because HTIF is not supported, so don't use the workaround on rv32.
+#if __riscv_xlen != 32
   printm("bbl loader\r\n");
+#endif
 
   hart_init();
   hls_init(0); // this might get called again from parse_config_string


### PR DESCRIPTION
As far as I could understand, the recently-added `printm` seems to prevent `pk` being usable at all on rv32 (e.g. https://github.com/riscv/riscv-pk/issues/92) because HTIF is not supported. Although there is some discussion and movement towards supporting the HTIF on rv32 in https://github.com/riscv/riscv-pk/pull/84, it would be good if `pk` didn't call `printm` on rv32 in the meantime so that it is usable again for rv32. This commit makes that so - however, I would be happy to revise it if there are other suggestions for how this should be worked around.

Tested with riscv32-unknown-elf and riscv64-unknown-elf - the string "bbl loader" only appears on riscv64, and riscv32 programs seem to execute and terminate normally.