### PR TITLE
Fix for missing supervisor mode when running on E51

### DIFF
--- a/machine/minit.c
+++ b/machine/minit.c
@@ -124,10 +124,17 @@ static void hart_plic_init()
     return;
 
   size_t ie_words = plic_ndevs / sizeof(uintptr_t) + 1;
-  for (size_t i = 0; i < ie_words; i++)
-    HLS()->plic_s_ie[i] = ULONG_MAX;
+  for (size_t i = 0; i < ie_words; i++) {
+     if (HLS()->plic_s_ie) {
+        // Supervisor not always present
+        HLS()->plic_s_ie[i] = ULONG_MAX;
+     }
+  }
   *HLS()->plic_m_thresh = 1;
-  *HLS()->plic_s_thresh = 0;
+  if (HLS()->plic_s_thresh) {
+      // Supervisor not always present
+      *HLS()->plic_s_thresh = 0;
+  }
 }
 
 static void wake_harts()


### PR DESCRIPTION
The E51 core on the U54-MC lacks supervisor mode, thus the plic_s_ie and plic_s_thresh are NULL when running on this core. This adds checks for this case.

Running bbl on the OVP model of the U54-MC device resulted in a null pointer error in the hart_plic_init() function. 

This occured because bbl ran on hart0 which is the E51 core  (at least in this model), which does not implement a supervisor mode. Thus there is no entry in the PLIC node of the device tree that sets the pointers for supervisor mode, plic_s_ie and plic_s_thresh, in the hls_t structure.

This error would not occur if the bbl were running on one of the U54 cores, but the [device documentation](https://www.sifive.com/documentation/risc-v-core/u54-mc-risc-v-core-ip-manual/) indicates hart0 should be the E51 and the bbl code specifically selects the hart with mhartid==0 to run on.
