### PR TITLE
Replace compile option m32 by march/mabi

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -52,12 +52,17 @@ endif
 
 prefix       := @prefix@
 enable_stow  := @enable_stow@
+ifeq (@BUILD_32BIT@, yes)
+  install_subdir := $(shell echo @host_alias@ | sed -e 's/64/32/g')
+else
+  install_subdir := @host_alias@
+endif
 
 ifeq ($(enable_stow),yes)
   stow_pkg_dir := $(prefix)/pkgs
   INSTALLDIR ?= $(DESTDIR)/$(stow_pkg_dir)/$(project_name)-$(project_ver)
 else
-  INSTALLDIR ?= $(DESTDIR)/$(prefix)/@install_subdir@
+  INSTALLDIR ?= $(DESTDIR)/$(prefix)/$(install_subdir)
 endif
 
 install_hdrs_dir := $(INSTALLDIR)/include/$(project_name)
@@ -116,6 +121,20 @@ INSTALL_HDR   := $(INSTALL) -m 444
 INSTALL_LIB   := $(INSTALL) -m 644
 INSTALL_EXE   := $(INSTALL) -m 555
 STOW          := @stow@
+
+# enable-32bit
+ifeq (@BUILD_32BIT@, yes)
+  opt_val = $(shell $(CC) -v 2>&1 | \
+              sed 's/ /\n/g' | grep $1 | awk -F= '{print $$2}' | sed 's/64/32/')
+  march := $(call opt_val,with-arch)
+  mabi := $(addprefix i,$(call opt_val,with-abi))
+  ifeq ($(mabi),)
+    is_fpu := $(or $(findstring g,$(march)),$(findstring d,$(march)))
+    mabi := $(if $(is_fpu),ilp32d,ilp32)
+  endif
+  COMPILE  += -march=$(march) -mabi=$(mabi)
+  LINK     += -march=$(march) -mabi=$(mabi)
+endif
 
 #-------------------------------------------------------------------------
 # Include subproject makefile fragments

--- a/configure
+++ b/configure
@@ -592,7 +592,7 @@ subprojects_enabled
 subprojects
 BBL_LOGO_FILE
 BBL_PAYLOAD
-install_subdir
+BUILD_32BIT
 RISCV
 EGREP
 GREP
@@ -4071,8 +4071,6 @@ fi
 # Set compiler flags
 #-------------------------------------------------------------------------
 
-default_CFLAGS="-Wall -Werror -D__NO_INLINE__ -mcmodel=medany -O2 -std=gnu99 -Wno-unused -Wno-attributes -fno-delete-null-pointer-checks -fno-PIE"
-
 # Check whether --enable-32bit was given.
 if test "${enable_32bit+set}" = set; then :
   enableval=$enable_32bit; BUILD_32BIT=$enableval
@@ -4081,22 +4079,8 @@ else
 fi
 
 
-case "${BUILD_32BIT}" in
-  yes|default)
-	echo "Building 32-bit pk"
-	CFLAGS="$default_CFLAGS -m32"
-	LDFLAGS="-m32"
-	install_subdir="`echo $host_alias | sed -e 's/64/32/g'`"
-	;;
-  *)
-	CFLAGS="$default_CFLAGS"
-	LDFLAGS=
-	install_subdir=$host_alias
-
-	;;
-esac
-
-LDFLAGS="$LDFLAGS -Wl,--build-id=none"
+CFLAGS="-Wall -Werror -D__NO_INLINE__ -mcmodel=medany -O2 -std=gnu99 -Wno-unused -Wno-attributes -fno-delete-null-pointer-checks -fno-PIE"
+LDFLAGS="-Wl,--build-id=none"
 
 # Check whether --enable-print-device-tree was given.
 if test "${enable_print_device_tree+set}" = set; then :

--- a/configure.ac
+++ b/configure.ac
@@ -78,28 +78,13 @@ AC_ARG_VAR(RISCV, [top-level RISC-V install directory])
 # Set compiler flags
 #-------------------------------------------------------------------------
 
-default_CFLAGS="-Wall -Werror -D__NO_INLINE__ -mcmodel=medany -O2 -std=gnu99 -Wno-unused -Wno-attributes -fno-delete-null-pointer-checks -fno-PIE"
-
 AC_ARG_ENABLE([32bit],
 	AS_HELP_STRING([--enable-32bit], [Build a 32-bit pk]),
 	BUILD_32BIT=$enableval,
 	BUILD_32BIT=no)
 
-case "${BUILD_32BIT}" in
-  yes|default)
-	echo "Building 32-bit pk"
-	CFLAGS="$default_CFLAGS -m32"
-	LDFLAGS="-m32"
-	install_subdir="`echo $host_alias | sed -e 's/64/32/g'`"
-	;;
-  *)
-	CFLAGS="$default_CFLAGS"
-	LDFLAGS=
-	install_subdir=$host_alias
-	;;
-esac
-
-LDFLAGS="$LDFLAGS -Wl,--build-id=none"
+CFLAGS="-Wall -Werror -D__NO_INLINE__ -mcmodel=medany -O2 -std=gnu99 -Wno-unused -Wno-attributes -fno-delete-null-pointer-checks -fno-PIE"
+LDFLAGS="-Wl,--build-id=none"
 
 AC_ARG_ENABLE([print-device-tree], AS_HELP_STRING([--enable-print-device-tree], [Print DTS when booting]))
 AS_IF([test "x$enable_print_device_tree" == "xyes"], [
@@ -109,7 +94,8 @@ AS_IF([test "x$enable_print_device_tree" == "xyes"], [
 AC_SUBST(CFLAGS)
 AC_SUBST(LDFLAGS)
 AC_SUBST([LIBS], ["-lgcc"])
-AC_SUBST(install_subdir)
+AC_SUBST(BUILD_32BIT)
+AC_SUBST(host_alias)
 
 #-------------------------------------------------------------------------
 # MCPPBS subproject list


### PR DESCRIPTION
Use gcc -v to get the march and mabi option from toolchain.

The --with-arch is exist certainly in toolchain,
but the --with-abi is uncertain.

If the --with-abi is not exist in toolchain,
using 'g' and 'd' extension in arch to deduce the abi