### PR TITLE
Replace the --enable-32bit option by --with-arch

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -48,6 +48,19 @@ else
   project_ver:=@PACKAGE_VERSION@
 endif
 
+# If --with-arch is not specified, it defaults to whatever the compiler's
+# default is. The -with-abi is not necessary for this project. Unconditionally
+# compile it with a no-float ABI. i.e., ilp32 for 32-bit and lp64 for 64-bit.
+
+ifeq (@WITH_ARCH@,)
+  march := -march=$(shell @CC@ -v 2>&1 | \
+                    sed 's/ /\n/g' | grep with-arch | awk -F= '{print $$2}')
+else
+  march := -march=@WITH_ARCH@
+endif
+is_32bit := $(findstring 32,$(march))
+mabi := -mabi=$(if $(is_32bit),ilp32,lp64)
+
 # Installation directories
 
 prefix       := @prefix@
@@ -57,7 +70,12 @@ ifeq ($(enable_stow),yes)
   stow_pkg_dir := $(prefix)/pkgs
   INSTALLDIR ?= $(DESTDIR)/$(stow_pkg_dir)/$(project_name)-$(project_ver)
 else
-  INSTALLDIR ?= $(DESTDIR)/$(prefix)/@install_subdir@
+  ifeq ($(is_32bit),)
+    install_subdir := @host_alias@
+  else
+    install_subdir := $(shell echo @host_alias@ | sed -e 's/64/32/g')
+  endif
+  INSTALLDIR ?= $(DESTDIR)/$(prefix)/$(install_subdir)
 endif
 
 install_hdrs_dir := $(INSTALLDIR)/include/$(project_name)
@@ -85,7 +103,7 @@ VPATH := $(addprefix $(src_dir)/, $(sprojs_enabled))
 CC            := @CC@
 READELF       := @READELF@
 OBJCOPY       := @OBJCOPY@
-CFLAGS        := @CFLAGS@ $(CFLAGS) -DBBL_PAYLOAD=\"bbl_payload\" -DBBL_LOGO_FILE=\"bbl_logo_file\"
+CFLAGS        := @CFLAGS@ $(CFLAGS) $(march) $(mabi) -DBBL_PAYLOAD=\"bbl_payload\" -DBBL_LOGO_FILE=\"bbl_logo_file\"
 BBL_PAYLOAD   := @BBL_PAYLOAD@
 COMPILE       := $(CC) -MMD -MP $(CFLAGS) \
                  $(sprojs_include)
@@ -94,7 +112,7 @@ COMPILE       := $(CC) -MMD -MP $(CFLAGS) \
 #  - LIBS    : Library flags (eg. -l)
 
 LD            := $(CC)
-LDFLAGS       := @LDFLAGS@ -nostartfiles -nostdlib -static $(LDFLAGS)
+LDFLAGS       := @LDFLAGS@ -nostartfiles -nostdlib -static $(LDFLAGS) $(march) $(mabi)
 LIBS          := @LIBS@
 LINK          := $(LD) $(LDFLAGS)
 

--- a/configure
+++ b/configure
@@ -592,7 +592,7 @@ subprojects_enabled
 subprojects
 BBL_LOGO_FILE
 BBL_PAYLOAD
-install_subdir
+WITH_ARCH
 RISCV
 EGREP
 GREP
@@ -669,7 +669,7 @@ ac_subst_files=''
 ac_user_opts='
 enable_option_checking
 enable_stow
-enable_32bit
+with_arch
 enable_print_device_tree
 enable_optional_subprojects
 enable_vm
@@ -1318,7 +1318,6 @@ Optional Features:
   --disable-FEATURE       do not include FEATURE (same as --enable-FEATURE=no)
   --enable-FEATURE[=ARG]  include FEATURE [ARG=yes]
   --enable-stow           Enable stow-based install
-  --enable-32bit          Build a 32-bit pk
   --enable-print-device-tree
                           Print DTS when booting
   --enable-optional-subprojects
@@ -1330,6 +1329,7 @@ Optional Features:
 Optional Packages:
   --with-PACKAGE[=ARG]    use PACKAGE [ARG=yes]
   --without-PACKAGE       do not use PACKAGE (same as --with-PACKAGE=no)
+  --with-arch             Set the RISC-V architecture
   --with-payload          Set ELF payload for bbl
   --with-logo             Specify a better logo
 
@@ -4071,31 +4071,12 @@ fi
 # Set compiler flags
 #-------------------------------------------------------------------------
 
-default_CFLAGS="-Wall -Werror -D__NO_INLINE__ -mcmodel=medany -O2 -std=gnu99 -Wno-unused -Wno-attributes -fno-delete-null-pointer-checks -fno-PIE"
 
-# Check whether --enable-32bit was given.
-if test "${enable_32bit+set}" = set; then :
-  enableval=$enable_32bit; BUILD_32BIT=$enableval
-else
-  BUILD_32BIT=no
+# Check whether --with-arch was given.
+if test "${with_arch+set}" = set; then :
+  withval=$with_arch; WITH_ARCH=$with_arch
+
 fi
-
-
-case "${BUILD_32BIT}" in
-  yes|default)
-	echo "Building 32-bit pk"
-	CFLAGS="$default_CFLAGS -m32"
-	LDFLAGS="-m32"
-	install_subdir="`echo $host_alias | sed -e 's/64/32/g'`"
-	;;
-  *)
-	CFLAGS="$default_CFLAGS"
-	LDFLAGS=
-	install_subdir=$host_alias
-	;;
-esac
-
-LDFLAGS="$LDFLAGS -Wl,--build-id=none"
 
 # Check whether --enable-print-device-tree was given.
 if test "${enable_print_device_tree+set}" = set; then :
@@ -4110,9 +4091,13 @@ $as_echo "#define PK_PRINT_DEVICE_TREE /**/" >>confdefs.h
 
 fi
 
+CFLAGS="-Wall -Werror -D__NO_INLINE__ -mcmodel=medany -O2 -std=gnu99 -Wno-unused -Wno-attributes -fno-delete-null-pointer-checks -fno-PIE"
+LDFLAGS="$LDFLAGS -Wl,--build-id=none"
+
 
 
 LIBS="-lgcc"
+
 
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -78,38 +78,22 @@ AC_ARG_VAR(RISCV, [top-level RISC-V install directory])
 # Set compiler flags
 #-------------------------------------------------------------------------
 
-default_CFLAGS="-Wall -Werror -D__NO_INLINE__ -mcmodel=medany -O2 -std=gnu99 -Wno-unused -Wno-attributes -fno-delete-null-pointer-checks -fno-PIE"
-
-AC_ARG_ENABLE([32bit],
-	AS_HELP_STRING([--enable-32bit], [Build a 32-bit pk]),
-	BUILD_32BIT=$enableval,
-	BUILD_32BIT=no)
-
-case "${BUILD_32BIT}" in
-  yes|default)
-	echo "Building 32-bit pk"
-	CFLAGS="$default_CFLAGS -m32"
-	LDFLAGS="-m32"
-	install_subdir="`echo $host_alias | sed -e 's/64/32/g'`"
-	;;
-  *)
-	CFLAGS="$default_CFLAGS"
-	LDFLAGS=
-	install_subdir=$host_alias
-	;;
-esac
-
-LDFLAGS="$LDFLAGS -Wl,--build-id=none"
+AC_ARG_WITH([arch], AS_HELP_STRING([--with-arch], [Set the RISC-V architecture]),
+  [AC_SUBST([WITH_ARCH], $with_arch, [Specify architecture to build the project])])
 
 AC_ARG_ENABLE([print-device-tree], AS_HELP_STRING([--enable-print-device-tree], [Print DTS when booting]))
 AS_IF([test "x$enable_print_device_tree" == "xyes"], [
   AC_DEFINE([PK_PRINT_DEVICE_TREE],,[Define if the DTS is to be displayed])
 ])
 
+CFLAGS="-Wall -Werror -D__NO_INLINE__ -mcmodel=medany -O2 -std=gnu99 -Wno-unused -Wno-attributes -fno-delete-null-pointer-checks -fno-PIE"
+LDFLAGS="$LDFLAGS -Wl,--build-id=none"
+
 AC_SUBST(CFLAGS)
 AC_SUBST(LDFLAGS)
 AC_SUBST([LIBS], ["-lgcc"])
-AC_SUBST(install_subdir)
+AC_SUBST(WITH_ARCH)
+AC_SUBST(host_alias)
 
 #-------------------------------------------------------------------------
 # MCPPBS subproject list


### PR DESCRIPTION
Get rid of the --enable-32bit option and switch to use --with-arch,
which is more standard because it matches the GCC build.

If --with-arch is not specified, it defaults to whatever the
compiler's default is.

The --with-abi is not necessary for this project.
Unconditionally compile it with a no-float ABI.