### PR TITLE
bbl: boot payload in machine mode on --enable-boot-machine

### DIFF
--- a/bbl/bbl.ac
+++ b/bbl/bbl.ac
@@ -18,3 +18,8 @@ AC_ARG_WITH([payload], AS_HELP_STRING([--with-payload], [Set ELF payload for bbl
 AC_ARG_WITH([logo], AS_HELP_STRING([--with-logo], [Specify a better logo]),
   [AC_SUBST([BBL_LOGO_FILE], $with_logo, [Logo for bbl])],
   [AC_SUBST([BBL_LOGO_FILE], [riscv_logo.txt], [Logo for bbl])])
+
+AC_ARG_ENABLE([boot-machine], AS_HELP_STRING([--enable-boot-machine], [Run payload in machine mode]))
+AS_IF([test "x$enable_boot_machine" == "xyes"], [
+  AC_DEFINE([BBL_BOOT_MACHINE],,[Define to run payload in machine mode])
+])

--- a/bbl/bbl.c
+++ b/bbl/bbl.c
@@ -58,7 +58,11 @@ void boot_other_hart(uintptr_t unused __attribute__((unused)))
     }
   }
 
+#ifdef BBL_BOOT_MACHINE
+  enter_machine_mode(entry, hartid, dtb_output());
+#else /* Run bbl in supervisor mode */
   enter_supervisor_mode(entry, hartid, dtb_output());
+#endif
 }
 
 void boot_loader(uintptr_t dtb)

--- a/config.h.in
+++ b/config.h.in
@@ -1,5 +1,8 @@
 /* config.h.in.  Generated from configure.ac by autoheader.  */
 
+/* Define to run payload in machine mode */
+#undef BBL_BOOT_MACHINE
+
 /* Define if subproject MCPPBS_SPROJ_NORM is enabled */
 #undef BBL_ENABLED
 

--- a/configure
+++ b/configure
@@ -677,6 +677,7 @@ enable_vm
 enable_logo
 with_payload
 with_logo
+enable_boot_machine
 enable_fp_emulation
 '
       ac_precious_vars='build_alias
@@ -1325,6 +1326,7 @@ Optional Features:
                           Enable all optional subprojects
   --disable-vm            Disable virtual memory
   --enable-logo           Enable boot logo
+  --enable-boot-machine   Run payload in machine mode
   --disable-fp-emulation  Disable floating-point emulation
 
 Optional Packages:
@@ -4271,6 +4273,19 @@ else
 
 fi
 
+
+# Check whether --enable-boot-machine was given.
+if test "${enable_boot_machine+set}" = set; then :
+  enableval=$enable_boot_machine;
+fi
+
+if test "x$enable_boot_machine" == "xyes"; then :
+
+
+$as_echo "#define BBL_BOOT_MACHINE /**/" >>confdefs.h
+
+
+fi
 
 
 

--- a/machine/mentry.S
+++ b/machine/mentry.S
@@ -2,6 +2,7 @@
 
 #include "mtrap.h"
 #include "bits.h"
+#include "config.h"
 
   .data
   .align 6
@@ -18,7 +19,11 @@ trap_table:
   .word bad_trap
   .word mcall_trap
   .word bad_trap
+#ifdef BBL_BOOT_MACHINE
+  .word mcall_trap
+#else
   .word bad_trap
+#endif /* BBL_BOOT_MACHINE */
   .word bad_trap
 #define TRAP_FROM_MACHINE_MODE_VECTOR 13
   .word __trap_from_machine_mode

--- a/machine/mtrap.h
+++ b/machine/mtrap.h
@@ -67,6 +67,8 @@ void putstring(const char* s);
 
 void enter_supervisor_mode(void (*fn)(uintptr_t), uintptr_t arg0, uintptr_t arg1)
   __attribute__((noreturn));
+void enter_machine_mode(void (*fn)(uintptr_t, uintptr_t), uintptr_t arg0, uintptr_t arg1)
+  __attribute__((noreturn));
 void boot_loader(uintptr_t dtb);
 void boot_other_hart(uintptr_t dtb);
 


### PR DESCRIPTION
If --disable-vm is passed, BBL disables VM and runs the payload in machine mode.
This is useful for payloads (e.g. RTOSes or other OSes) that want to run
only in machine mode while still relying on bbl/pk for system calls and emulation

When passed, --disable-vm implicitly runs the payload in machine mode

