### PR TITLE
machine,minit: initialize emulated FCSR in enter_supervisor_mode()

### DIFF
--- a/machine/minit.c
+++ b/machine/minit.c
@@ -197,6 +197,10 @@ void enter_supervisor_mode(void (*fn)(uintptr_t), uintptr_t arg0, uintptr_t arg1
   mstatus = INSERT_FIELD(mstatus, MSTATUS_MPIE, 0);
   write_csr(mstatus, mstatus);
   write_csr(mscratch, MACHINE_STACK_TOP() - MENTRY_FRAME_SIZE);
+#ifndef __riscv_flen
+  uintptr_t *p_fcsr = MACHINE_STACK_TOP() - MENTRY_FRAME_SIZE; // the x0's save slot
+  *p_fcsr = 0;
+#endif
   write_csr(mepc, fn);
 
   register uintptr_t a0 asm ("a0") = arg0;


### PR DESCRIPTION
* If BBL emulates the FPU, the trap handler will load emulated FCSR from
  x0's save slot into tp. The emulated FCSR should be initialized, else
  the field of rounding mode will contain garbage codes. This will
  lead to raising SIGABRT for a user mode program which tries to print a
  floating point variable. In glibc, __printf_fp_l() (defined in
  riscv-glibc/stdio-common/printf_fp.c) will call round_away() (defined
  in riscv-glibc/include/rounding-mode.h). With a garbage rounding mode
  in emulated FCSR, round_away() may call abort().