### PR TITLE
Support timer interrupt pending clear in SBI

### DIFF
--- a/machine/mcall.h
+++ b/machine/mcall.h
@@ -10,5 +10,6 @@
 #define SBI_REMOTE_SFENCE_VMA 6
 #define SBI_REMOTE_SFENCE_VMA_ASID 7
 #define SBI_SHUTDOWN 8
+#define SBI_CLEAR_TIP 9
 
 #endif

--- a/machine/mtrap.c
+++ b/machine/mtrap.c
@@ -79,6 +79,11 @@ static uintptr_t mcall_clear_ipi()
   return clear_csr(mip, MIP_SSIP) & MIP_SSIP;
 }
 
+static uintptr_t mcall_clear_tip()
+{
+  return clear_csr(mip, MIP_STIP);
+}
+
 static uintptr_t mcall_shutdown()
 {
   poweroff(0);
@@ -87,7 +92,7 @@ static uintptr_t mcall_shutdown()
 static uintptr_t mcall_set_timer(uint64_t when)
 {
   *HLS()->timecmp = when;
-  clear_csr(mip, MIP_STIP);
+  mcall_clear_tip();
   set_csr(mie, MIP_MTIP);
   return 0;
 }
@@ -151,6 +156,9 @@ send_ipi:
       break;
     case SBI_CLEAR_IPI:
       retval = mcall_clear_ipi();
+      break;
+    case SBI_CLEAR_TIP:
+      retval = mcall_clear_tip();
       break;
     case SBI_SHUTDOWN:
       retval = mcall_shutdown();


### PR DESCRIPTION
As per the privileged spec, timer interrupt pending bit should
be cleared by calling into SEE. Currently, SBI doesn't support
a method to achieve that.

Introduce a method to clear the timer interrupt pending bit in
interrupt pending csr.

Signed-off-by: Atish Patra <atish.patra@wdc.com>