### PR TITLE
Fix stubs-lp64.h/stubs-lp64d.h/stubs-ilp32.h/stubs-ilp32d.h not found

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -54,14 +54,11 @@ endif
 # default is. The -with-abi is not necessary for this project. Unconditionally
 # compile it with a no-float ABI. i.e., ilp32 for 32-bit and lp64 for 64-bit.
 
-ifeq (@WITH_ARCH@,)
-  march := -march=$(shell @CC@ -v 2>&1 | \
-                    sed 's/ /\n/g' | grep with-arch | awk -F= '{print $$2}')
-else
+ifneq (@WITH_ARCH@,)
   march := -march=@WITH_ARCH@
+  is_32bit := $(findstring 32,$(march))
+  mabi := -mabi=$(if $(is_32bit),ilp32,lp64)
 endif
-is_32bit := $(findstring 32,$(march))
-mabi := -mabi=$(if $(is_32bit),ilp32,lp64)
 
 # Installation directories
 


### PR DESCRIPTION
For now, we always compile files with -mabi option by using
soft-fp ABI. But there are some files use the header which in
toolchain, like unistd.h, stdint.h and so on. Finally, these
header files include other header files which existing depend
on ABI such as stubs-lp64.h or stubs-lp64d.h. So it causes the
header file not found when using the double-float toolchain with
soft-float ABI.

Fix up by compiling files with -march and -mabi options only if
there is specifying the --with-arch option at configure time.

If use the --with-arch option at configure time, that means your
toolchain has multi-lib support, so always building riscv-pk
by soft-float ABI is fine. Otherwise, we don't compile files with
specifying march and mabi options explicitly