### PR TITLE
Fix bug of mcall_set_timer

### DIFF
--- a/machine/mtrap.c
+++ b/machine/mtrap.c
@@ -88,6 +88,7 @@ static uintptr_t mcall_shutdown()
 
 static uintptr_t mcall_set_timer(uint64_t when)
 {
+  *HLS()->time = 0;
   *HLS()->timecmp = when;
   clear_csr(mip, MIP_STIP);
   set_csr(mie, MIP_MTIP);


### PR DESCRIPTION
mcall_set_timer is used to set the timed event. If only timecmp is set, there will be no timing effect.