### PR TITLE
Fix broken submodule, replace with link to source version

### DIFF
--- a/softfloat/README.md
+++ b/softfloat/README.md
@@ -1,0 +1,10 @@
+# Berkeley SoftFloat
+
+- http://www.jhauser.us/arithmetic/SoftFloat.html
+
+## Release 3e
+
+Release 3 was a complete rewrite of SoftFloat, funded
+by the University of California, Berkeley.
+
+- http://www.jhauser.us/arithmetic/SoftFloat-3e.zip


### PR DESCRIPTION
Adding empty directories to the index breaks git-submodule. This repo doesn't have any submodules however the empty berkeley-softfloat-3 directory screws up some build script automation that runs `git submodule update --init --recursive`. There is probably some other way around this problem. _git fsck_ doesn't pick it up.

This changes adds a README.md indicating where to retrieve the upstream sources.

_(BTW: it seems one has to manually futz with git update-index to get an empty directory into the index, and apparently this empty dir problem is a known issue with git-submodule)_.