### PR TITLE
Don't require a RISC-V libc and crt when configuring

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -114,7 +114,7 @@ COMPILE       := $(CC) -MMD -MP $(CFLAGS) \
 #  - LIBS    : Library flags (eg. -l)
 
 LD            := $(CC)
-LDFLAGS       := @LDFLAGS@ -nostartfiles -nostdlib -static $(LDFLAGS) $(march) $(mabi)
+LDFLAGS       := @LDFLAGS@ $(LDFLAGS) $(march) $(mabi)
 LIBS          := @LIBS@
 LINK          := $(LD) $(LDFLAGS)
 

--- a/configure
+++ b/configure
@@ -2043,6 +2043,7 @@ case $host_os in *\ *) host_os=`echo "$host_os" | sed 's/ /-/g'`;; esac
 # Checks for programs
 #-------------------------------------------------------------------------
 
+LDFLAGS="$LDFLAGS -nostartfiles -nostdlib -static"
 ac_ext=c
 ac_cpp='$CPP $CPPFLAGS'
 ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'

--- a/configure.ac
+++ b/configure.ac
@@ -48,6 +48,7 @@ AC_CANONICAL_HOST
 # Checks for programs
 #-------------------------------------------------------------------------
 
+LDFLAGS="$LDFLAGS -nostartfiles -nostdlib -static"
 AC_PROG_CC
 AC_PROG_CXX
 AC_CHECK_TOOL([AR],[ar])


### PR DESCRIPTION
We're always linking statically without a libc and crt files, but at configure time autoconf tries to link an executable, and will fail to do unless you have these available, so we should set LDFLAGS before performing any configure checks.