### PR TITLE
Fix the calculation for the number of interrupt enable words

### DIFF
--- a/machine/minit.c
+++ b/machine/minit.c
@@ -129,7 +129,8 @@ static void hart_plic_init()
   if (!plic_ndevs)
     return;
 
-  size_t ie_words = plic_ndevs / sizeof(uintptr_t) + 1;
+  size_t ie_words = (plic_ndevs + 8 * sizeof(uintptr_t) - 1) /
+		(8 * sizeof(uintptr_t));
   for (size_t i = 0; i < ie_words; i++) {
      if (HLS()->plic_s_ie) {
         // Supervisor not always present


### PR DESCRIPTION
The number of interrupt enable words should be the number of devices
divided by the number of bits per word (not the number of bytes per
word) and it should round up.

Without this fix, when using a larger number of interrupts,
the user will see a number of errors in qemu of the form:

   `plic: invalid register write: %08x`
