### PR TITLE
Use PMP to protect the loader from S-mode payloads

### DIFF
--- a/bbl/bbl.c
+++ b/bbl/bbl.c
@@ -40,6 +40,52 @@ static void filter_dtb(uintptr_t source)
   filter_compat(dest, "riscv,debug-013");
 }
 
+static void protect_memory(void)
+{
+  // Check to see if up to four PMP registers are implemented.
+  // Ignore the illegal-instruction trap if PMPs aren't supported.
+  uintptr_t a0 = 0, a1 = 0, a2 = 0, a3 = 0, tmp, cfg;
+  asm volatile ("la %[tmp], 1f\n\t"
+                "csrrw %[tmp], mtvec, %[tmp]\n\t"
+                "csrw pmpaddr0, %[m1]\n\t"
+                "csrr %[a0], pmpaddr0\n\t"
+                "csrw pmpaddr1, %[m1]\n\t"
+                "csrr %[a1], pmpaddr1\n\t"
+                "csrw pmpaddr2, %[m1]\n\t"
+                "csrr %[a2], pmpaddr2\n\t"
+                "csrw pmpaddr3, %[m1]\n\t"
+                "csrr %[a3], pmpaddr3\n\t"
+                ".align 2\n\t"
+                "1: csrw mtvec, %[tmp]"
+                : [tmp] "=&r" (tmp),
+                  [a0] "+r" (a0), [a1] "+r" (a1), [a2] "+r" (a2), [a3] "+r" (a3)
+                : [m1] "r" (-1UL));
+
+  // We need at least four PMP registers to protect M-mode from S-mode.
+  if (!(a0 & a1 & a2 & a3))
+    return setup_pmp();
+
+  // Prevent S-mode access to our part of memory.
+  extern char _ftext, _etext, _end;
+  a0 = (uintptr_t)&_ftext >> PMP_SHIFT;
+  a1 = (uintptr_t)&_etext >> PMP_SHIFT;
+  cfg = PMP_TOR << 8;
+  // Give S-mode free rein of everything else.
+  a2 = -1;
+  cfg |= (PMP_NAPOT | PMP_R | PMP_W | PMP_X) << 16;
+  // No use for PMP 3 just yet.
+  a3 = 0;
+
+  // Plug it all in.
+  asm volatile ("csrw pmpaddr0, %[a0]\n\t"
+                "csrw pmpaddr1, %[a1]\n\t"
+                "csrw pmpaddr2, %[a2]\n\t"
+                "csrw pmpaddr3, %[a3]\n\t"
+                "csrw pmpcfg0, %[cfg]"
+                :: [a0] "r" (a0), [a1] "r" (a1), [a2] "r" (a2), [a3] "r" (a3),
+                   [cfg] "r" (cfg));
+}
+
 void boot_other_hart(uintptr_t unused __attribute__((unused)))
 {
   const void* entry;
@@ -61,6 +107,7 @@ void boot_other_hart(uintptr_t unused __attribute__((unused)))
 #ifdef BBL_BOOT_MACHINE
   enter_machine_mode(entry, hartid, dtb_output());
 #else /* Run bbl in supervisor mode */
+  protect_memory();
   enter_supervisor_mode(entry, hartid, dtb_output());
 #endif
 }

--- a/bbl/bbl.lds
+++ b/bbl/bbl.lds
@@ -38,12 +38,12 @@ SECTIONS
   }
 
   /* End of code and read-only segment */
+  . = ALIGN(0x1000);
   _etext = .;
 
   /*--------------------------------------------------------------------*/
   /* HTIF, isolated onto separate page                                  */
   /*--------------------------------------------------------------------*/
-  . = ALIGN(0x1000);
   .htif :
   {
     PROVIDE( __htif_base = . );
@@ -96,10 +96,11 @@ SECTIONS
     *(COMMON)
   }
 
+  . = ALIGN(0x1000);
+  _end = .;
+
   .payload :
   {
     *(.payload)
   }
-
-  _end = .;
 }

--- a/bbl/bbl.lds
+++ b/bbl/bbl.lds
@@ -14,7 +14,6 @@ SECTIONS
   /* Begining of code and text segment */
   . = 0x80000000;
   _ftext = .;
-  PROVIDE( eprol = . );
 
   .text :
   {
@@ -39,7 +38,6 @@ SECTIONS
   }
 
   /* End of code and read-only segment */
-  PROVIDE( etext = . );
   _etext = .;
 
   /*--------------------------------------------------------------------*/
@@ -48,7 +46,7 @@ SECTIONS
   . = ALIGN(0x1000);
   .htif :
   {
-    PROVIDE( __htif_base = .);
+    PROVIDE( __htif_base = . );
     *(.htif)
   }
   . = ALIGN(0x1000);
@@ -72,8 +70,7 @@ SECTIONS
   }
 
   /* End of initialized data segment */
-  . = ALIGN(4);
-  PROVIDE( edata = . );
+  . = ALIGN(16);
   _edata = .;
 
   /*--------------------------------------------------------------------*/
@@ -97,11 +94,6 @@ SECTIONS
     *(.sbss*)
     *(.gnu.linkonce.b.*)
     *(COMMON)
-  }
-
-  .sbi :
-  {
-    *(.sbi)
   }
 
   .payload :

--- a/machine/minit.c
+++ b/machine/minit.c
@@ -98,6 +98,7 @@ static void hart_init()
 #ifndef BBL_BOOT_MACHINE
   delegate_traps();
 #endif /* BBL_BOOT_MACHINE */
+  setup_pmp();
 }
 
 static void plic_init()
@@ -187,7 +188,7 @@ void init_other_hart(uintptr_t hartid, uintptr_t dtb)
   boot_other_hart(dtb);
 }
 
-static inline void setup_pmp(void)
+void setup_pmp(void)
 {
   // Set up a PMP to permit access to all of memory.
   // Ignore the illegal-instruction trap if PMPs aren't supported.
@@ -203,8 +204,6 @@ static inline void setup_pmp(void)
 
 void enter_supervisor_mode(void (*fn)(uintptr_t), uintptr_t arg0, uintptr_t arg1)
 {
-  setup_pmp();
-
   uintptr_t mstatus = read_csr(mstatus);
   mstatus = INSERT_FIELD(mstatus, MSTATUS_MPP, PRV_S);
   mstatus = INSERT_FIELD(mstatus, MSTATUS_MPIE, 0);
@@ -224,8 +223,6 @@ void enter_supervisor_mode(void (*fn)(uintptr_t), uintptr_t arg0, uintptr_t arg1
 
 void enter_machine_mode(void (*fn)(uintptr_t, uintptr_t), uintptr_t arg0, uintptr_t arg1)
 {
-  setup_pmp();
-
   uintptr_t mstatus = read_csr(mstatus);
   mstatus = INSERT_FIELD(mstatus, MSTATUS_MPIE, 0);
   write_csr(mstatus, mstatus);

--- a/machine/mtrap.h
+++ b/machine/mtrap.h
@@ -65,6 +65,7 @@ void putstring(const char* s);
 #define assert(x) ({ if (!(x)) die("assertion failed: %s", #x); })
 #define die(str, ...) ({ printm("%s:%d: " str "\n", __FILE__, __LINE__, ##__VA_ARGS__); poweroff(-1); })
 
+void setup_pmp();
 void enter_supervisor_mode(void (*fn)(uintptr_t), uintptr_t arg0, uintptr_t arg1)
   __attribute__((noreturn));
 void enter_machine_mode(void (*fn)(uintptr_t, uintptr_t), uintptr_t arg0, uintptr_t arg1)

--- a/pk/pk.lds
+++ b/pk/pk.lds
@@ -38,12 +38,12 @@ SECTIONS
   }
 
   /* End of code and read-only segment */
+  . = ALIGN(0x1000);
   _etext = .;
 
   /*--------------------------------------------------------------------*/
   /* HTIF, isolated onto separate page                                  */
   /*--------------------------------------------------------------------*/
-  . = ALIGN(0x1000);
   .htif :
   {
     PROVIDE( __htif_base = . );
@@ -96,5 +96,6 @@ SECTIONS
     *(COMMON)
   }
 
+  . = ALIGN(0x1000);
   _end = .;
 }

--- a/pk/pk.lds
+++ b/pk/pk.lds
@@ -14,7 +14,6 @@ SECTIONS
   /* Begining of code and text segment */
   . = 0x80000000;
   _ftext = .;
-  PROVIDE( eprol = . );
 
   .text :
   {
@@ -39,7 +38,6 @@ SECTIONS
   }
 
   /* End of code and read-only segment */
-  PROVIDE( etext = . );
   _etext = .;
 
   /*--------------------------------------------------------------------*/
@@ -72,8 +70,7 @@ SECTIONS
   }
 
   /* End of initialized data segment */
-  . = ALIGN(4);
-  PROVIDE( edata = . );
+  . = ALIGN(16);
   _edata = .;
 
   /*--------------------------------------------------------------------*/


### PR DESCRIPTION
The purpose of this isn't ironclad security; this loader is still written to assume the S-mode payload is trusted.  The intent is to catch OS bugs early: the OS should never be accessing the loader's memory.