### PR TITLE
Revert "Don't require a RISC-V libc and crt when configuring"

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -111,7 +111,7 @@ COMPILE       := $(CC) -MMD -MP $(CFLAGS) \
 #  - LIBS    : Library flags (eg. -l)
 
 LD            := $(CC)
-LDFLAGS       := @LDFLAGS@ $(LDFLAGS) $(march) $(mabi)
+LDFLAGS       := @LDFLAGS@ -nostartfiles -nostdlib -static $(LDFLAGS) $(march) $(mabi)
 LIBS          := @LIBS@
 LINK          := $(LD) $(LDFLAGS)
 

--- a/configure
+++ b/configure
@@ -2043,7 +2043,6 @@ case $host_os in *\ *) host_os=`echo "$host_os" | sed 's/ /-/g'`;; esac
 # Checks for programs
 #-------------------------------------------------------------------------
 
-LDFLAGS="$LDFLAGS -nostartfiles -nostdlib -static"
 ac_ext=c
 ac_cpp='$CPP $CPPFLAGS'
 ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'

--- a/configure.ac
+++ b/configure.ac
@@ -48,7 +48,6 @@ AC_CANONICAL_HOST
 # Checks for programs
 #-------------------------------------------------------------------------
 
-LDFLAGS="$LDFLAGS -nostartfiles -nostdlib -static"
 AC_PROG_CC
 AC_PROG_CXX
 AC_CHECK_TOOL([AR],[ar])


### PR DESCRIPTION
Reverts riscv/riscv-pk#132

See comments on #132 for explanation