### PR TITLE
Stub out madvise syscall

### DIFF
--- a/pk/syscall.c
+++ b/pk/syscall.c
@@ -471,6 +471,7 @@ long do_syscall(long a0, long a1, long a2, long a3, long a4, long a5, unsigned l
     [SYS_chdir] = sys_chdir,
     [SYS_set_tid_address] = sys_stub_nosys,
     [SYS_set_robust_list] = sys_stub_nosys,
+    [SYS_madvise] = sys_stub_nosys,
   };
 
   const static void* old_syscall_table[] = {

--- a/pk/syscall.h
+++ b/pk/syscall.h
@@ -52,6 +52,7 @@
 #define SYS_clock_gettime 113
 #define SYS_set_tid_address 96
 #define SYS_set_robust_list 99
+#define SYS_madvise 233
 
 #define OLD_SYSCALL_THRESHOLD 1024
 #define SYS_open 1024


### PR DESCRIPTION
This is needed for some programs linked with musl.