### PR TITLE
Build fixes

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -102,7 +102,7 @@ VPATH := $(addprefix $(src_dir)/, $(sprojs_enabled))
 CC            := @CC@
 READELF       := @READELF@
 OBJCOPY       := @OBJCOPY@
-CFLAGS        := @CFLAGS@ $(CFLAGS) $(march) $(mabi) -DBBL_PAYLOAD=\"bbl_payload\" -DBBL_LOGO_FILE=\"bbl_logo_file\"
+CFLAGS        := @CFLAGS@ $(CFLAGS) $(march) $(mabi) -DBBL_PAYLOAD=\"bbl_payload\" -DBBL_LOGO_FILE=\"bbl_logo_file\" -fno-stack-protector -U_FORTIFY_SOURCE
 BBL_PAYLOAD   := @BBL_PAYLOAD@
 COMPILE       := $(CC) -MMD -MP $(CFLAGS) \
                  $(sprojs_include)
@@ -111,7 +111,7 @@ COMPILE       := $(CC) -MMD -MP $(CFLAGS) \
 #  - LIBS    : Library flags (eg. -l)
 
 LD            := $(CC)
-LDFLAGS       := @LDFLAGS@ -nostartfiles -nostdlib -static $(LDFLAGS) $(march) $(mabi)
+LDFLAGS       := @LDFLAGS@ -nostartfiles -nostdlib -static $(LDFLAGS) $(march) $(mabi) -fno-stack-protector
 LIBS          := @LIBS@
 LINK          := $(LD) $(LDFLAGS)
 

--- a/Makefile.in
+++ b/Makefile.in
@@ -283,11 +283,11 @@ $$($(2)_install_prog_exes) : % : %.o $$($(2)_prog_libnames)
 $(2)_c_deps += $$($(2)_install_prog_deps)
 $(2)_junk += \
   $$($(2)_install_prog_objs) $$($(2)_install_prog_deps) \
-  $$($(2)_install_prog_exes)
+  $$($(2)_install_prog_exes) $($(2)_extra_targets)
 
 # Subproject specific targets
 
-all-$(1) : lib$(1).a $$($(2)_install_prog_exes)
+all-$(1) : lib$(1).a $$($(2)_install_prog_exes) $($(2)_extra_targets)
 
 check-$(1) : $$($(2)_test_outs)
 	echo; grep -h -e'Unit Tests' -e'FAILED' -e'Segementation' $$^; echo
@@ -311,6 +311,7 @@ test_outs += $$($(2)_test_outs)
 install_hdrs += $$(addprefix $(src_dir)/$(1)/, $$($(2)_hdrs))
 install_libs += lib$(1).a
 install_exes += $$($(2)_install_prog_exes)
+extra_targets += $($(2)_extra_targets)
 
 endef
 
@@ -446,7 +447,7 @@ junk += $(project_name)-*.tar.gz
 # Default
 #-------------------------------------------------------------------------
 
-all : $(install_hdrs) $(install_libs) $(install_exes)
+all : $(install_hdrs) $(install_libs) $(install_exes) $(extra_targets)
 .PHONY : all
 
 #-------------------------------------------------------------------------

--- a/bbl/bbl.mk.in
+++ b/bbl/bbl.mk.in
@@ -35,3 +35,8 @@ bbl_test_srcs =
 
 bbl_install_prog_srcs = \
   bbl.c \
+
+bbl.bin: bbl
+	$(OBJCOPY) -S -O binary --change-addresses -0x80000000 $< $@
+
+bbl_extra_targets = bbl.bin


### PR DESCRIPTION
Two patches:

1) The first one fixes the build issues when using the compiler that's readily available in Ubuntu. This is the issue dismissed in #105. There's nothing wrong with this compiler except it enables stack protection and FORTIFY_SOURCE by default and we don't want these for riscv-pk. Adding flags to disable them allows us to use the compiler with no ill effects. The compiler readily available in Debian does not have this problem and is not affected by the flags.

2) Always create bbl.bin with objcopy which is typically used by real hardware (qemu likes the ELF bbl). This was done in the freedom-u-sdk, but using that SDK is a giant pain and building our kernels manually is much easier. So it's much prefered for this file to be created by riscv-pk as well.

Thanks,

Logan