### PR TITLE
Update configure option for 32-bit

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Alternatively, the GNU/Linux toolchain may be used to build this package,
 by setting `--host=riscv64-unknown-linux-gnu`.
 
 By default, 64-bit (RV64) versions of `pk` and `bbl` are built.  To
-built 32-bit (RV32) versions, supply a `--enable-32bit` flag to the
+built 32-bit (RV32) versions, supply a `--with-arch=rv32i` flag to the
 configure command.
 
 The `install` step installs 64-bit build products into a directory


### PR DESCRIPTION
configure script does not support --enable-32bit option since June 2018
(commit c3cf29a8f2f5f6a0b793bd1f24b083a759370a01). The right step
to enable 32-bit support in pk is to provide '--with-arch=rv32i' option to
configure.