### PR TITLE
configure.ac: use = instead of == to check for equality

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -84,7 +84,7 @@ AC_ARG_WITH([arch], AS_HELP_STRING([--with-arch], [Set the RISC-V architecture])
   [AC_SUBST([WITH_ARCH], $with_arch, [Specify architecture to build the project])])
 
 AC_ARG_ENABLE([print-device-tree], AS_HELP_STRING([--enable-print-device-tree], [Print DTS when booting]))
-AS_IF([test "x$enable_print_device_tree" == "xyes"], [
+AS_IF([test "x$enable_print_device_tree" = "xyes"], [
   AC_DEFINE([PK_PRINT_DEVICE_TREE],,[Define if the DTS is to be displayed])
 ])
 


### PR DESCRIPTION
== is not specified by POSIX and will fail if a POSIX shell is called
which is done by the configure script.

Related to: https://github.com/void-linux/void-packages/issues/10949