### PR TITLE
bbl/bbl.ac: use = instead of == for comparing equality

### DIFF
--- a/bbl/bbl.ac
+++ b/bbl/bbl.ac
@@ -1,7 +1,7 @@
 # See LICENSE for license details.
 
 AC_ARG_ENABLE([logo], AS_HELP_STRING([--enable-logo], [Enable boot logo]))
-AS_IF([test "x$enable_logo" == "xyes"], [
+AS_IF([test "x$enable_logo" = "xyes"], [
   AC_SUBST([BBL_ENABLE_LOGO], 1)
   AC_DEFINE([PK_ENABLE_LOGO],,[Define if the RISC-V logo is to be displayed])
 ])
@@ -20,6 +20,6 @@ AC_ARG_WITH([logo], AS_HELP_STRING([--with-logo], [Specify a better logo]),
   [AC_SUBST([BBL_LOGO_FILE], [riscv_logo.txt], [Logo for bbl])])
 
 AC_ARG_ENABLE([boot-machine], AS_HELP_STRING([--enable-boot-machine], [Run payload in machine mode]))
-AS_IF([test "x$enable_boot_machine" == "xyes"], [
+AS_IF([test "x$enable_boot_machine" = "xyes"], [
   AC_DEFINE([BBL_BOOT_MACHINE],,[Define to run payload in machine mode])
 ])


### PR DESCRIPTION
== is not defined in POSIX and will fail when configure
is called with shells that adhere strictly to POSIX like
dash