### PR TITLE
Building BBL for the LiteX/Rocket SoC

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -278,7 +278,7 @@ $$($(2)_install_prog_objs) : %.o : %.c
 	$(COMPILE) -c $$<
 
 $$($(2)_install_prog_exes) : % : %.o $$($(2)_prog_libnames)
-	$(LINK) -o $$@ $$< $$($(2)_prog_libarg) $(LIBS) -T $(src_dir)/$(2)/$(2).lds
+	$(LINK) -o $$@ $$< $$($(2)_prog_libarg) $(LIBS) -Wl,--defsym=MEM_START=@MEM_START@,-T,$(src_dir)/$(2)/$(2).lds
 
 $(2)_c_deps += $$($(2)_install_prog_deps)
 $(2)_junk += \

--- a/bbl/bbl.lds
+++ b/bbl/bbl.lds
@@ -12,7 +12,7 @@ SECTIONS
   /*--------------------------------------------------------------------*/
 
   /* Begining of code and text segment */
-  . = 0x80000000;
+  . = MEM_START;
   _ftext = .;
 
   .text :

--- a/configure
+++ b/configure
@@ -593,6 +593,7 @@ subprojects
 BBL_LOGO_FILE
 BBL_PAYLOAD
 BBL_ENABLE_LOGO
+MEM_START
 WITH_ARCH
 RISCV
 EGREP
@@ -672,6 +673,7 @@ enable_option_checking
 enable_stow
 with_arch
 enable_print_device_tree
+with_mem_start
 enable_optional_subprojects
 enable_vm
 enable_logo
@@ -1333,6 +1335,7 @@ Optional Packages:
   --with-PACKAGE[=ARG]    use PACKAGE [ARG=yes]
   --without-PACKAGE       do not use PACKAGE (same as --with-PACKAGE=no)
   --with-arch             Set the RISC-V architecture
+  --with-mem-start        Set physical memory start address
   --with-payload          Set ELF payload for bbl
   --with-logo             Specify a better logo
 
@@ -4103,6 +4106,21 @@ LDFLAGS="$LDFLAGS -Wl,--build-id=none"
 LIBS="-lgcc"
 
 
+
+
+
+# Check whether --with-mem-start was given.
+if test "${with_mem_start+set}" = set; then :
+  withval=$with_mem_start;
+   MEM_START=$with_mem_start
+
+
+else
+
+   MEM_START=0x80000000
+
+
+fi
 
 
 #-------------------------------------------------------------------------

--- a/configure.ac
+++ b/configure.ac
@@ -97,6 +97,13 @@ AC_SUBST([LIBS], ["-lgcc"])
 AC_SUBST(WITH_ARCH)
 AC_SUBST(host_alias)
 
+AC_ARG_WITH([mem-start], AS_HELP_STRING([--with-mem-start], [Set physical memory start address]),
+  [
+   AC_SUBST([MEM_START], $with_mem_start, [Physical memory start address])
+  ], [
+   AC_SUBST([MEM_START], [0x80000000], [Physical memory start address])
+  ])
+
 #-------------------------------------------------------------------------
 # MCPPBS subproject list
 #-------------------------------------------------------------------------

--- a/machine/minit.c
+++ b/machine/minit.c
@@ -30,7 +30,8 @@ static void mstatus_init()
   // Enable user/supervisor use of perf counters
   if (supports_extension('S'))
     write_csr(scounteren, -1);
-  write_csr(mcounteren, -1);
+  if (supports_extension('U'))
+    write_csr(mcounteren, -1);
 
   // Enable software interrupts
   write_csr(mie, MIP_MSIP);

--- a/pk/pk.lds
+++ b/pk/pk.lds
@@ -12,7 +12,7 @@ SECTIONS
   /*--------------------------------------------------------------------*/
 
   /* Begining of code and text segment */
-  . = 0x80000000;
+  . = MEM_START;
   _ftext = .;
 
   .text :


### PR DESCRIPTION
The LiteX SoC (https://github.com/enjoy-digital/litex) is now capable of hosting a 64-bit Rocket Chip as one of its CPU choices.

The enclosed patches allow BBL to be loaded by the LiteX/Rocket SoC:

1. LiteX uses a 64-bit Rocket variant built using `DefaultFPGAConfig` and `WithNSmallCores`, which doesn't support `U` mode and traps when `mcounteren` is accessed.
2. LiteX maps physical ram to `0x40000000`, so the hard-coded assumption of `0x80000000` needs to become an override-able default in pk/bbl.