### PR TITLE
Fixes for booting with code above 2^32

### DIFF
--- a/machine/emulation.c
+++ b/machine/emulation.c
@@ -145,6 +145,11 @@ void illegal_insn_trap(uintptr_t* regs, uintptr_t mcause, uintptr_t mepc)
   extern uint32_t illegal_insn_trap_table[];
   uint32_t* pf = (void*)illegal_insn_trap_table + (insn & 0x7c);
   emulation_func f = (emulation_func)(uintptr_t)*pf;
+#if __INTPTR_WIDTH__ == 64
+  uint64_t addr = f;
+  addr |= ((uint64_t)illegal_insn_trap) & 0xffffffff00000000;
+  f = (emulation_func)addr;
+#endif
   f(regs, mcause, mepc, mstatus, insn);
 }
 

--- a/machine/mentry.S
+++ b/machine/mentry.S
@@ -116,7 +116,12 @@ trap_vector:
   STORE t2, 7*REGBYTES(sp)
   add t1, t0, t1                   # t1 <- %hi(trap_table)[mcause]
   STORE s0, 8*REGBYTES(sp)
+
+  auipc t2, %pcrel_hi(trap_table)
+  srli t2, t2, 32
+  slli t2, t2, 32
   LWU t1, %pcrel_lo(1b)(t1)         # t1 <- trap_table[mcause]
+  or t1, t1, t2
   STORE s1, 9*REGBYTES(sp)
   mv a0, sp                        # a0 <- regs
   STORE a2,12*REGBYTES(sp)


### PR DESCRIPTION
I ran into two problems trying to boot on a system where memory is mapped above 0x100000000. This exposed bugs in the trap handler and illegal_inst_trap() when they compute the location of the handler function.