### PR TITLE
allow additional ns16550a config via device tree

### DIFF
--- a/machine/fdt.c
+++ b/machine/fdt.c
@@ -126,6 +126,11 @@ const uint32_t *fdt_get_size(const struct fdt_scan_node *node, const uint32_t *v
   return value;
 }
 
+uint32_t fdt_get_value(const struct fdt_scan_prop *prop, uint32_t index)
+{
+  return bswap(prop->value[index]);
+}
+
 int fdt_string_list_index(const struct fdt_scan_prop *prop, const char *str)
 {
   const char *list = (const char *)prop->value;

--- a/machine/fdt.h
+++ b/machine/fdt.h
@@ -54,6 +54,7 @@ uint32_t fdt_size(uintptr_t fdt);
 // Extract fields
 const uint32_t *fdt_get_address(const struct fdt_scan_node *node, const uint32_t *base, uint64_t *value);
 const uint32_t *fdt_get_size(const struct fdt_scan_node *node, const uint32_t *base, uint64_t *value);
+uint32_t fdt_get_value(const struct fdt_scan_prop *prop, uint32_t index);
 int fdt_string_list_index(const struct fdt_scan_prop *prop, const char *str); // -1 if not found
 
 // Setup memory+clint+plic


### PR DESCRIPTION
This commit makes bbl read some additional fields from
the device tree if it detects an ns16550a:

- reg-shift
- reg-offset
- clock-frequency

For explanation of these check out the Linux Kernel doc:
https://www.kernel.org/doc/Documentation/devicetree/bindings/serial/8250.txt

In particular this allows the Xilinx AXI UART 16550 to act
as serial console with bbl and the Linux early boot console.

This also fixes a bug in which bbl will ignore any other than the first
"compatible" string when iterating over the nodes.
Previously this line would not have worked:

compatible = "xlnx,xps-uart16550-2.00.a", "ns16550a";

Before bbl would have just checked the first field instead of checking
all strings in the list.