### PR TITLE
Try to work with linux kernel specified compat strings

### DIFF
--- a/machine/uart.c
+++ b/machine/uart.c
@@ -47,6 +47,9 @@ static void uart_prop(const struct fdt_scan_prop *prop, void *extra)
   struct uart_scan *scan = (struct uart_scan *)extra;
   if (!strcmp(prop->name, "compatible") && !strcmp((const char*)prop->value, "sifive,uart0")) {
     scan->compat = 1;
+  } else if(!strcmp(prop->name, "compatible") && !strcmp((const char*)prop->value,
+	"sifive,fu540-c000-uart")) {
+    scan->compat = 1;
   } else if (!strcmp(prop->name, "reg")) {
     fdt_get_address(prop->node->parent, prop->value, &scan->reg);
   }


### PR DESCRIPTION
Work with the new linux 'compatible' strings for uart