### PR TITLE
fdt: allow mmu type "riscv,32" on rv32 systems

### DIFF
--- a/machine/fdt.c
+++ b/machine/fdt.c
@@ -651,8 +651,12 @@ static bool hart_filter_mask(const struct hart_filter *filter)
 {
   if (filter->mmu_type == NULL) return true;
   if (strcmp(filter->status, "okay")) return true;
+#if __riscv_xlen == 32
+  if (!strcmp(filter->mmu_type, "riscv,sv32")) return false;
+#else
   if (!strcmp(filter->mmu_type, "riscv,sv39")) return false;
   if (!strcmp(filter->mmu_type, "riscv,sv48")) return false;
+#endif
   printm("hart_filter_mask saw unknown hart type: status=\"%s\", mmu_type=\"%s\"\n",
          filter->status, filter->mmu_type);
   return true;


### PR DESCRIPTION
SV32 is presented in RISC-V Privileged Architecture Manual (version
20190608-Priv-MSU-Ratified) Section 4.3 for RV32 systems. However, BBL
responds to sv32 with:

  hart_filter_mask saw unknown hart type: status="okay", mmu_type="riscv,sv32"

and hangs.

This patch is adopted from the original 'riscv-pk.diff' patch written
by Fabrice Bellard, distributed as part of the following tarball:
https://bellard.org/tinyemu/diskimage-linux-riscv-2018-09-23.tar.gz

Closes: https://github.com/riscv/riscv-pk/issues/160