### PR TITLE
Init mstatus for vector extension

### DIFF
--- a/machine/encoding.h
+++ b/machine/encoding.h
@@ -16,6 +16,7 @@
 #define MSTATUS_MPP         0x00001800
 #define MSTATUS_VS          0x01800000
 #define MSTATUS_FS          0x00006000
+#define MSTATUS_VS          0x01800000
 #define MSTATUS_XS          0x00018000
 #define MSTATUS_MPRV        0x00020000
 #define MSTATUS_SUM         0x00040000
@@ -35,6 +36,7 @@
 #define SSTATUS_SPP         0x00000100
 #define SSTATUS_VS          0x01800000
 #define SSTATUS_FS          0x00006000
+#define SSTATUS_VS          0x01800000
 #define SSTATUS_XS          0x00018000
 #define SSTATUS_SUM         0x00040000
 #define SSTATUS_MXR         0x00080000

--- a/machine/minit.c
+++ b/machine/minit.c
@@ -35,6 +35,9 @@ static void mstatus_init()
 
   write_csr(mstatus, mstatus);
 
+  if (supports_extension('V'))
+    write_csr(mstatus, MSTATUS_FS | read_csr(mstatus));
+
   // Enable user/supervisor use of perf counters
   if (supports_extension('S'))
     write_csr(scounteren, -1);


### PR DESCRIPTION
spike will check mstatus.vs at https://github.com/riscv/riscv-isa-sim/commit/4051af5ce64a78c2d032ba7b0452b8bb929ac281 , so we must init mstatus.vs if vector extension enabled.