### PR TITLE
Support --without-payload for OpenSBI fw_jump-style booting

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -111,7 +111,10 @@ VPATH := $(addprefix $(src_dir)/, $(sprojs_enabled))
 CC            := @CC@
 READELF       := @READELF@
 OBJCOPY       := @OBJCOPY@
-CFLAGS        := @CFLAGS@ $(CFLAGS) $(march) $(mabi) -DBBL_PAYLOAD=\"bbl_payload\" -DBBL_LOGO_FILE=\"bbl_logo_file\" -fno-stack-protector -U_FORTIFY_SOURCE
+CFLAGS        := @CFLAGS@ $(CFLAGS) $(march) $(mabi) -DBBL_LOGO_FILE=\"bbl_logo_file\" -DMEM_START=@MEM_START@ -fno-stack-protector -U_FORTIFY_SOURCE
+ifneq (@BBL_PAYLOAD@,no)
+CFLAGS        := $(CFLAGS) -DBBL_PAYLOAD=\"bbl_payload\"
+endif
 BBL_PAYLOAD   := @BBL_PAYLOAD@
 COMPILE       := $(CC) -MMD -MP $(CFLAGS) \
                  $(sprojs_include)

--- a/bbl/bbl.mk.in
+++ b/bbl/bbl.mk.in
@@ -4,7 +4,6 @@ bbl_subproject_deps = \
 	util \
   softfloat \
   machine \
-  dummy_payload \
 
 bbl_hdrs = \
   bbl.h \
@@ -13,13 +12,22 @@ bbl_c_srcs = \
   logo.c \
 
 bbl_asm_srcs = \
-  payload.S \
   raw_logo.S \
+
+ifeq (@BBL_PAYLOAD@,dummy_payload)
+bbl_subproject_deps += \
+  dummy_payload
+endif
+
+ifneq (@BBL_PAYLOAD@,no)
+bbl_asm_srcs += \
+  payload.S
 
 payload.o: bbl_payload
 
 bbl_payload: $(BBL_PAYLOAD)
 	if $(READELF) -h $< 2> /dev/null > /dev/null; then $(OBJCOPY) -O binary --set-section-flags .bss=alloc,load,contents $< $@; else cp $< $@; fi
+endif
 
 raw_logo.o: bbl_logo_file
 


### PR DESCRIPTION
We expect the firmware to load the external payload at the second
megapage, and that there is space to put the filtered FDT at 0x2200000
past the start of memory. With a default MEM_START of 0x80000000, this
matches the standard OpenSBI values for FW_JUMP_ADDR and
FW_JUMP_FDT_ADDR of 0x80400000/0x80200000 (RV32/RV64) and 0x82200000
respectively, so payloads linked for one should work with the other.