### PR TITLE
Support manually zeroing out BSS when booting

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -56,3 +56,6 @@
 
 /* Define if subproject MCPPBS_SPROJ_NORM is enabled */
 #undef UTIL_ENABLED
+
+/* Define if BSS should be manually zeroed when booting */
+#undef ZERO_BSS

--- a/configure
+++ b/configure
@@ -675,6 +675,7 @@ with_arch
 with_abi
 enable_print_device_tree
 with_mem_start
+enable_zero_bss
 enable_optional_subprojects
 enable_vm
 enable_logo
@@ -1314,6 +1315,7 @@ Optional Features:
   --enable-stow           Enable stow-based install
   --enable-print-device-tree
                           Print DTS when booting
+  --enable-zero-bss       Manually zero out BSS when booting
   --enable-optional-subprojects
                           Enable all optional subprojects
   --disable-vm            Disable virtual memory
@@ -4121,6 +4123,19 @@ else
 
 fi
 
+
+# Check whether --enable-zero-bss was given.
+if test "${enable_zero_bss+set}" = set; then :
+  enableval=$enable_zero_bss;
+fi
+
+if test "x$enable_zero_bss" = "xyes"; then :
+
+
+$as_echo "#define ZERO_BSS /**/" >>confdefs.h
+
+
+fi
 
 #-------------------------------------------------------------------------
 # MCPPBS subproject list

--- a/configure.ac
+++ b/configure.ac
@@ -107,6 +107,11 @@ AC_ARG_WITH([mem-start], AS_HELP_STRING([--with-mem-start], [Set physical memory
    AC_SUBST([MEM_START], [0x80000000], [Physical memory start address])
   ])
 
+AC_ARG_ENABLE([zero-bss], AS_HELP_STRING([--enable-zero-bss], [Manually zero out BSS when booting]))
+AS_IF([test "x$enable_zero_bss" = "xyes"], [
+  AC_DEFINE([ZERO_BSS],,[Define if BSS should be manually zeroed when booting])
+])
+
 #-------------------------------------------------------------------------
 # MCPPBS subproject list
 #-------------------------------------------------------------------------

--- a/machine/mentry.S
+++ b/machine/mentry.S
@@ -267,9 +267,23 @@ do_reset:
   slli a2, a3, RISCV_PGSHIFT
   add sp, sp, a2
 
-  # Boot on the first hart
-  beqz a3, init_first_hart
+  bnez a3, .LmultiHartInit
 
+#ifdef ZERO_BSS
+  # Zero out BSS; linker script provides alignment and padding
+  la t0, _fbss
+  la t1, _end
+  beq t0, t1, 2f
+1:STORE zero, 0(t0)
+  addi t0, t0, REGBYTES
+  bne t0, t1, 1b
+2:
+#endif
+
+  # Boot on the first hart
+  j init_first_hart
+
+.LmultiHartInit:
   # set MSIE bit to receive IPI
   li a2, MIP_MSIP
   csrw mie, a2


### PR DESCRIPTION
Some ELF loaders, in particular gdb's load command for dynamically
loading files into memory, which is often used to load binaries onto
FPGAs over JTAG, do not zero out BSS, leaving the memory in whatever
state it was previously in. Thus, introduce a new --enable-zero-bss
configure flag, which will include code to zero out BSS when booting.