### PR TITLE
Fix CPI calcualtion for -s option

### DIFF
--- a/pk/syscall.c
+++ b/pk/syscall.c
@@ -24,7 +24,7 @@ void sys_exit(int code)
     printk("%lld cycles\n", dc);
     printk("%lld instructions\n", di);
     printk("%d.%d%d CPI\n", (int)(dc/di), (int)(10ULL*dc/di % 10),
-        (int)((100ULL*dc + di/2)/di % 10));
+        (int)((100ULL*dc)/di % 10));
   }
   shutdown(code);
 }


### PR DESCRIPTION
This attempt at rounding leads to wrong results, for example:
314689951 cycles
314690101 instructions
0.90 CPI
With my change results in:
314689951 cycles
314690101 instructions
0.99 CPI
I think this was supposed to be part of rounding behaviour but it doesn't work if only the final digit does it and there is no carry...
Instead I changed it to truncate after the second digit