### PR TITLE
Consistently use fdt_string_list for FDT compatible property

### DIFF
--- a/machine/finisher.c
+++ b/machine/finisher.c
@@ -31,7 +31,7 @@ static void finisher_open(const struct fdt_scan_node *node, void *extra)
 static void finisher_prop(const struct fdt_scan_prop *prop, void *extra)
 {
   struct finisher_scan *scan = (struct finisher_scan *)extra;
-  if (!strcmp(prop->name, "compatible") && !strcmp((const char*)prop->value, "sifive,test0")) {
+  if (!strcmp(prop->name, "compatible") && fdt_string_list_index(prop, "sifive,test0") >= 0) {
     scan->compat = 1;
   } else if (!strcmp(prop->name, "reg")) {
     fdt_get_address(prop->node->parent, prop->value, &scan->reg);

--- a/machine/htif.c
+++ b/machine/htif.c
@@ -128,7 +128,7 @@ static void htif_open(const struct fdt_scan_node *node, void *extra)
 static void htif_prop(const struct fdt_scan_prop *prop, void *extra)
 {
   struct htif_scan *scan = (struct htif_scan *)extra;
-  if (!strcmp(prop->name, "compatible") && !strcmp((const char*)prop->value, "ucb,htif0")) {
+  if (!strcmp(prop->name, "compatible") && fdt_string_list_index(prop, "ucb,htif0") >= 0) {
     scan->compat = 1;
   }
 }

--- a/machine/uart.c
+++ b/machine/uart.c
@@ -45,7 +45,7 @@ static void uart_open(const struct fdt_scan_node *node, void *extra)
 static void uart_prop(const struct fdt_scan_prop *prop, void *extra)
 {
   struct uart_scan *scan = (struct uart_scan *)extra;
-  if (!strcmp(prop->name, "compatible") && !strcmp((const char*)prop->value, "sifive,uart0")) {
+  if (!strcmp(prop->name, "compatible") && fdt_string_list_index(prop, "sifive,uart0") >= 0) {
     scan->compat = 1;
   } else if (!strcmp(prop->name, "reg")) {
     fdt_get_address(prop->node->parent, prop->value, &scan->reg);


### PR DESCRIPTION
QEMU's finisher is "sifive,test1\0sifive,test0\0syscon" so we fail to
detect it currently. Instead, search the entire list, and for
completeness do the same with the HTIF and SiFive UART drivers.