### PR TITLE
Don't perform 64-bit accesses to the PLIC

### DIFF
--- a/machine/fdt.c
+++ b/machine/fdt.c
@@ -439,10 +439,10 @@ static void plic_done(const struct fdt_scan_node *node, void *extra)
     if (hart < MAX_HARTS) {
       hls_t *hls = OTHER_HLS(hart);
       if (cpu_int == IRQ_M_EXT) {
-        hls->plic_m_ie     = (uintptr_t*)((uintptr_t)scan->reg + ENABLE_BASE + ENABLE_SIZE * index);
+        hls->plic_m_ie     = (uint32_t*)((uintptr_t)scan->reg + ENABLE_BASE + ENABLE_SIZE * index);
         hls->plic_m_thresh = (uint32_t*) ((uintptr_t)scan->reg + HART_BASE   + HART_SIZE   * index);
       } else if (cpu_int == IRQ_S_EXT) {
-        hls->plic_s_ie     = (uintptr_t*)((uintptr_t)scan->reg + ENABLE_BASE + ENABLE_SIZE * index);
+        hls->plic_s_ie     = (uint32_t*)((uintptr_t)scan->reg + ENABLE_BASE + ENABLE_SIZE * index);
         hls->plic_s_thresh = (uint32_t*) ((uintptr_t)scan->reg + HART_BASE   + HART_SIZE   * index);
       } else {
         printm("PLIC wired hart %d to wrong interrupt %d", hart, cpu_int);

--- a/machine/minit.c
+++ b/machine/minit.c
@@ -146,12 +146,12 @@ static void hart_plic_init()
   if (!plic_ndevs)
     return;
 
-  size_t ie_words = (plic_ndevs + 8 * sizeof(uintptr_t) - 1) /
-		(8 * sizeof(uintptr_t));
+  size_t ie_words = (plic_ndevs + 8 * sizeof(*HLS()->plic_s_ie) - 1) /
+		(8 * sizeof(*HLS()->plic_s_ie));
   for (size_t i = 0; i < ie_words; i++) {
      if (HLS()->plic_s_ie) {
         // Supervisor not always present
-        HLS()->plic_s_ie[i] = ULONG_MAX;
+        HLS()->plic_s_ie[i] = __UINT32_MAX__;
      }
   }
   *HLS()->plic_m_thresh = 1;

--- a/machine/mtrap.h
+++ b/machine/mtrap.h
@@ -43,9 +43,9 @@ typedef struct {
   volatile uint64_t* timecmp;
 
   volatile uint32_t* plic_m_thresh;
-  volatile uintptr_t* plic_m_ie;
+  volatile uint32_t* plic_m_ie;
   volatile uint32_t* plic_s_thresh;
-  volatile uintptr_t* plic_s_ie;
+  volatile uint32_t* plic_s_ie;
 } hls_t;
 
 #define MACHINE_STACK_TOP() ({ \


### PR DESCRIPTION
Recent QEMU will fault for 8-byte accesses. Use a uint32_t instead of
uintptr_t to avoid those problems.