### PR TITLE
Fix UART register map

### DIFF
--- a/machine/uart.h
+++ b/machine/uart.h
@@ -11,7 +11,9 @@ extern volatile uint32_t* uart;
 #define UART_REG_RXFIFO		1
 #define UART_REG_TXCTRL		2
 #define UART_REG_RXCTRL		3
-#define UART_REG_DIV		4
+#define UART_REG_IE			4
+#define UART_REG_IP			5
+#define UART_REG_DIV			6
 
 #define UART_TXEN		 0x1
 #define UART_RXEN		 0x1


### PR DESCRIPTION
While it's unused upstream, according to the SiFive FU540 document, the
UART divisor register is at offset 0x18.

This also maps the interrupt enable and interrupt pending register
offsets.