### PR TITLE
Make htif_poweroff thread-safe

### DIFF
--- a/machine/htif.c
+++ b/machine/htif.c
@@ -109,8 +109,9 @@ void htif_console_putchar(uint8_t ch)
 void htif_poweroff()
 {
   while (1) {
-    fromhost = 0;
-    tohost = 1;
+    spinlock_lock(&htif_lock);
+    __set_tohost(0, 0, 1);
+    spinlock_unlock(&htif_lock);
   }
 }
 


### PR DESCRIPTION
This fixes an issue we were seeing in which a dual-core BOOM simulation wasn't shutting down properly. I believe the root cause was that the core calling htif_poweroff was getting into a data race with the other core calling htif_console_getchar. Having htif_poweroff take the htif lock and use __set_tohost to write the tohost register seems to solve the issue. 