### PR TITLE
Disable device tree filter when load a dts from file

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -116,10 +116,10 @@ ifneq (@BBL_PAYLOAD@,no)
 CFLAGS        := $(CFLAGS) -DBBL_PAYLOAD=\"bbl_payload\"
 endif
 BBL_PAYLOAD   := @BBL_PAYLOAD@
-ifneq (@MACHINE_DTS@,no)
-CFLAGS        := $(CFLAGS) -DMACHINE_DTS=\"machine_dts\"
+ifneq (@CUSTOM_DTS@,no)
+CFLAGS        := $(CFLAGS) -DCUSTOM_DTS=\"custom_dts\"
 endif
-MACHINE_DTS   := @MACHINE_DTS@
+CUSTOM_DTS   := @CUSTOM_DTS@
 COMPILE       := $(CC) -MMD -MP $(CFLAGS) \
                  $(sprojs_include)
 # Linker

--- a/Makefile.in
+++ b/Makefile.in
@@ -116,6 +116,10 @@ ifneq (@BBL_PAYLOAD@,no)
 CFLAGS        := $(CFLAGS) -DBBL_PAYLOAD=\"bbl_payload\"
 endif
 BBL_PAYLOAD   := @BBL_PAYLOAD@
+ifneq (@MACHINE_DTS@,no)
+CFLAGS        := $(CFLAGS) -DMACHINE_DTS=\"machine_dts\"
+endif
+MACHINE_DTS   := @MACHINE_DTS@
 COMPILE       := $(CC) -MMD -MP $(CFLAGS) \
                  $(sprojs_include)
 # Linker

--- a/bbl/bbl.c
+++ b/bbl/bbl.c
@@ -41,7 +41,7 @@ static void filter_dtb(uintptr_t source)
   uint32_t size = fdt_size(source);
   memcpy((void*)dest, (void*)source, size);
 
-#ifndef MACHINE_DTS
+#ifndef CUSTOM_DTS
   // Remove information from the chained FDT
   filter_harts(dest, &disabled_hart_mask);
   filter_plic(dest);

--- a/bbl/bbl.c
+++ b/bbl/bbl.c
@@ -41,11 +41,13 @@ static void filter_dtb(uintptr_t source)
   uint32_t size = fdt_size(source);
   memcpy((void*)dest, (void*)source, size);
 
+#ifndef MACHINE_DTS
   // Remove information from the chained FDT
   filter_harts(dest, &disabled_hart_mask);
   filter_plic(dest);
   filter_compat(dest, "riscv,clint0");
   filter_compat(dest, "riscv,debug-013");
+#endif
 }
 
 static void protect_memory(void)

--- a/bbl/bbl.lds
+++ b/bbl/bbl.lds
@@ -67,6 +67,7 @@ SECTIONS
     *(.srodata*)
     *(.gnu.linkonce.d.*)
     *(.comment)
+    *(.dtb)
   }
 
   /* End of initialized data segment */

--- a/configure
+++ b/configure
@@ -590,7 +590,7 @@ ac_subst_vars='LTLIBOBJS
 LIBOBJS
 subprojects_enabled
 subprojects
-MACHINE_DTS
+CUSTOM_DTS
 BBL_LOGO_FILE
 BBL_PAYLOAD
 BBL_ENABLE_LOGO
@@ -1345,7 +1345,7 @@ Optional Packages:
   --with-mem-start        Set physical memory start address
   --with-payload          Set ELF payload for bbl
   --with-logo             Specify a better logo
-  --with-dts              Support a machine dts
+  --with-dts              Specify a customize dts
 
 Some influential environment variables:
   CC          C compiler command
@@ -4486,7 +4486,10 @@ fi
 
 # Check whether --with-dts was given.
 if test "${with_dts+set}" = set; then :
-  withval=$with_dts; MACHINE_DTS=$with_dts
+  withval=$with_dts; CUSTOM_DTS=$with_dts
+
+else
+  CUSTOM_DTS=no
 
 
 fi

--- a/configure
+++ b/configure
@@ -590,6 +590,7 @@ ac_subst_vars='LTLIBOBJS
 LIBOBJS
 subprojects_enabled
 subprojects
+MACHINE_DTS
 BBL_LOGO_FILE
 BBL_PAYLOAD
 BBL_ENABLE_LOGO
@@ -648,6 +649,7 @@ infodir
 docdir
 oldincludedir
 includedir
+runstatedir
 localstatedir
 sharedstatedir
 sysconfdir
@@ -683,6 +685,7 @@ with_payload
 with_logo
 enable_boot_machine
 enable_fp_emulation
+with_dts
 '
       ac_precious_vars='build_alias
 host_alias
@@ -737,6 +740,7 @@ datadir='${datarootdir}'
 sysconfdir='${prefix}/etc'
 sharedstatedir='${prefix}/com'
 localstatedir='${prefix}/var'
+runstatedir='${localstatedir}/run'
 includedir='${prefix}/include'
 oldincludedir='/usr/include'
 docdir='${datarootdir}/doc/${PACKAGE_TARNAME}'
@@ -989,6 +993,15 @@ do
   | -silent | --silent | --silen | --sile | --sil)
     silent=yes ;;
 
+  -runstatedir | --runstatedir | --runstatedi | --runstated \
+  | --runstate | --runstat | --runsta | --runst | --runs \
+  | --run | --ru | --r)
+    ac_prev=runstatedir ;;
+  -runstatedir=* | --runstatedir=* | --runstatedi=* | --runstated=* \
+  | --runstate=* | --runstat=* | --runsta=* | --runst=* | --runs=* \
+  | --run=* | --ru=* | --r=*)
+    runstatedir=$ac_optarg ;;
+
   -sbindir | --sbindir | --sbindi | --sbind | --sbin | --sbi | --sb)
     ac_prev=sbindir ;;
   -sbindir=* | --sbindir=* | --sbindi=* | --sbind=* | --sbin=* \
@@ -1126,7 +1139,7 @@ fi
 for ac_var in	exec_prefix prefix bindir sbindir libexecdir datarootdir \
 		datadir sysconfdir sharedstatedir localstatedir includedir \
 		oldincludedir docdir infodir htmldir dvidir pdfdir psdir \
-		libdir localedir mandir
+		libdir localedir mandir runstatedir
 do
   eval ac_val=\$$ac_var
   # Remove trailing slashes.
@@ -1279,6 +1292,7 @@ Fine tuning of the installation directories:
   --sysconfdir=DIR        read-only single-machine data [PREFIX/etc]
   --sharedstatedir=DIR    modifiable architecture-independent data [PREFIX/com]
   --localstatedir=DIR     modifiable single-machine data [PREFIX/var]
+  --runstatedir=DIR       modifiable per-process data [LOCALSTATEDIR/run]
   --libdir=DIR            object code libraries [EPREFIX/lib]
   --includedir=DIR        C header files [PREFIX/include]
   --oldincludedir=DIR     C header files for non-gcc [/usr/include]
@@ -1331,6 +1345,7 @@ Optional Packages:
   --with-mem-start        Set physical memory start address
   --with-payload          Set ELF payload for bbl
   --with-logo             Specify a better logo
+  --with-dts              Support a machine dts
 
 Some influential environment variables:
   CC          C compiler command
@@ -4467,6 +4482,15 @@ $as_echo "#define PK_ENABLE_FP_EMULATION /**/" >>confdefs.h
 
 
 fi
+
+
+# Check whether --with-dts was given.
+if test "${with_dts+set}" = set; then :
+  withval=$with_dts; MACHINE_DTS=$with_dts
+
+
+fi
+
 
 
 

--- a/machine/machine.ac
+++ b/machine/machine.ac
@@ -4,3 +4,7 @@ AC_ARG_ENABLE([fp-emulation], AS_HELP_STRING([--disable-fp-emulation], [Disable 
 AS_IF([test "x$enable_fp_emulation" != "xno"], [
   AC_DEFINE([PK_ENABLE_FP_EMULATION],,[Define if floating-point emulation is enabled])
 ])
+
+AC_ARG_WITH([dts], AS_HELP_STRING([--with-dts], [Support a machine dts]),
+  [AC_SUBST([MACHINE_DTS], $with_dts, [machine dts])]
+)

--- a/machine/machine.ac
+++ b/machine/machine.ac
@@ -5,6 +5,7 @@ AS_IF([test "x$enable_fp_emulation" != "xno"], [
   AC_DEFINE([PK_ENABLE_FP_EMULATION],,[Define if floating-point emulation is enabled])
 ])
 
-AC_ARG_WITH([dts], AS_HELP_STRING([--with-dts], [Support a machine dts]),
-  [AC_SUBST([MACHINE_DTS], $with_dts, [machine dts])]
+AC_ARG_WITH([dts], AS_HELP_STRING([--with-dts], [Specify a customize dts]),
+  [AC_SUBST([CUSTOM_DTS], $with_dts, [customize dts])],
+  [AC_SUBST([CUSTOM_DTS], [no], [customize dts])]
 )

--- a/machine/machine.mk.in
+++ b/machine/machine.mk.in
@@ -37,3 +37,8 @@ machine_c_srcs = \
 machine_asm_srcs = \
   mentry.S \
   fp_asm.S \
+  
+mentry.o: machine.dtb
+
+machine.dtb: $(MACHINE_DTS)
+	dtc -O dtb $^ -o $@

--- a/machine/machine.mk.in
+++ b/machine/machine.mk.in
@@ -37,8 +37,10 @@ machine_c_srcs = \
 machine_asm_srcs = \
   mentry.S \
   fp_asm.S \
-  
-mentry.o: machine.dtb
 
-machine.dtb: $(MACHINE_DTS)
+ifneq (@CUSTOM_DTS@,no)
+mentry.o: custom.dtb
+
+custom.dtb: $(CUSTOM_DTS)
 	dtc -O dtb $^ -o $@
+endif

--- a/machine/mentry.S
+++ b/machine/mentry.S
@@ -281,7 +281,7 @@ do_reset:
 #endif
 
   # Boot on the first hart
-#ifdef MACHINE_DTS
+#ifdef CUSTOM_DTS
   csrr a0, mhartid
   la a1, dtb_start
 #endif
@@ -317,12 +317,12 @@ do_reset:
   wfi
   j .LmultiHart
 
-#ifdef MACHINE_DTS
+#ifdef CUSTOM_DTS
 .section .dtb
 .align 3
 .global dtb_start, dtb_end
 dtb_start:
-.incbin "machine.dtb"
+.incbin "custom.dtb"
 dtb_end:
 #endif
 

--- a/machine/mentry.S
+++ b/machine/mentry.S
@@ -281,6 +281,10 @@ do_reset:
 #endif
 
   # Boot on the first hart
+#ifdef MACHINE_DTS
+  csrr a0, mhartid
+  la a1, dtb_start
+#endif
   j init_first_hart
 
 .LmultiHartInit:
@@ -312,6 +316,15 @@ do_reset:
 #endif
   wfi
   j .LmultiHart
+
+#ifdef MACHINE_DTS
+.section .dtb
+.align 3
+.global dtb_start, dtb_end
+dtb_start:
+.incbin "machine.dtb"
+dtb_end:
+#endif
 
   .bss
   .align RISCV_PGSHIFT


### PR DESCRIPTION
In past versions, bbl would filter the device tree to maintain compatibility. Now with the development of software systems, most of the device tree properties are supported by linux and we don't need this filtering anymore. bbl is just a simple bootloader, although in practice we should use opensbi, but in order to enable bbl to boot linux on more complex devices, I have added the --with-dts option and when this option is enabled, we can specify a device tree file to describe the onboard resources, and properties will not be filtered out by default.