### PR TITLE
Remove use of copy_stat() from sys_fstatat

### DIFF
--- a/pk/syscall.c
+++ b/pk/syscall.c
@@ -226,7 +226,7 @@ long sys_fstatat(int dirfd, const char* name, void* st, int flags)
     struct frontend_stat buf;
     size_t name_size = strlen(name)+1;
     long ret = frontend_syscall(SYS_fstatat, kfd, va2pa(name), name_size, va2pa(&buf), flags, 0, 0);
-    copy_stat(st, &buf);
+    memcpy(st, &buf, sizeof(buf));
     return ret;
   }
   return -EBADF;


### PR DESCRIPTION
Fixes #221 

I have tested this with both a newlib and a glibc payload program.