### PR TITLE
Add `statx` syscall

### DIFF
--- a/pk/frontend.h
+++ b/pk/frontend.h
@@ -32,4 +32,6 @@ struct frontend_stat {
   uint32_t __unused5;
 };
 
+#define FRONTEND_STATX_SIZE 256
+
 #endif

--- a/pk/syscall.c
+++ b/pk/syscall.c
@@ -312,6 +312,25 @@ long sys_stat(const char* name, void* st)
   return sys_fstatat(AT_FDCWD, name, st, 0);
 }
 
+long sys_statx(int dirfd, const char* name, int flags, unsigned int mask, void * st)
+{
+  int kfd = at_kfd(dirfd);
+  if (kfd != -1) {
+    char buf[FRONTEND_STATX_SIZE];
+
+    char kname[MAX_BUF];
+    if (!strcpy_from_user(kname, name, MAX_BUF))
+      return -ENAMETOOLONG;
+
+    size_t name_size = strlen(kname)+1;
+
+    long ret = frontend_syscall(SYS_statx, kfd, kva2pa(kname), name_size, flags, mask, kva2pa(&buf), 0);
+    memcpy_to_user(st, &buf, sizeof(buf));
+    return ret;
+  }
+  return -EBADF;
+}
+
 long sys_faccessat(int dirfd, const char *name, int mode)
 {
   int kfd = at_kfd(dirfd);
@@ -571,6 +590,7 @@ long do_syscall(long a0, long a1, long a2, long a3, long a4, long a5, unsigned l
     [SYS_openat] = sys_openat,
     [SYS_close] = sys_close,
     [SYS_fstat] = sys_fstat,
+    [SYS_statx] = sys_statx,
     [SYS_lseek] = sys_lseek,
     [SYS_fstatat] = sys_fstatat,
     [SYS_linkat] = sys_linkat,

--- a/pk/syscall.h
+++ b/pk/syscall.h
@@ -54,6 +54,7 @@
 #define SYS_set_tid_address 96
 #define SYS_set_robust_list 99
 #define SYS_madvise 233
+#define SYS_statx 291
 
 #define OLD_SYSCALL_THRESHOLD 1024
 #define SYS_open 1024


### PR DESCRIPTION
The `statx` syscall is required to run some 32bit programs on Spike and `riscv-pk`, so i tried to add it to the proxy kernel. :)

Please let me know if there exist some problems with the code.