### PR TITLE
LiteX UART: fix compatible property name

### DIFF
--- a/machine/uart_litex.c
+++ b/machine/uart_litex.c
@@ -45,7 +45,8 @@ static void uart_litex_prop(const struct fdt_scan_prop *prop, void *extra)
 {
     struct uart_litex_scan *scan = (struct uart_litex_scan *)extra;
     if (!strcmp(prop->name, "compatible") &&
-        !strcmp((const char *)prop->value, "litex,uart0")) {
+        (!strcmp((const char *)prop->value, "litex,uart0") ||
+         !strcmp((const char *)prop->value, "litex,liteuart"))) {
         scan->compat = 1;
     } else if (!strcmp(prop->name, "reg")) {
         fdt_get_address(prop->node->parent, prop->value, &scan->reg);

--- a/pk/elf.c
+++ b/pk/elf.c
@@ -5,6 +5,7 @@
 #include "boot.h"
 #include "bits.h"
 #include "elf.h"
+#include "usermem.h"
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <string.h>
@@ -83,7 +84,7 @@ void load_elf(const char* fn, elf_info* info)
       int prot = get_prot(ph[i].p_flags);
       if (__do_mmap(vaddr - prepad, ph[i].p_filesz + prepad, prot | PROT_WRITE, flags2, file, ph[i].p_offset - prepad) != vaddr - prepad)
         goto fail;
-      memset((void*)vaddr - prepad, 0, prepad);
+      memset_user((void*)vaddr - prepad, 0, prepad);
       if (!(prot & PROT_WRITE))
         if (do_mprotect(vaddr - prepad, ph[i].p_filesz + prepad, prot))
           goto fail;

--- a/pk/file.c
+++ b/pk/file.c
@@ -105,7 +105,7 @@ file_t* file_openat(int dirfd, const char* fn, int flags, int mode)
     return ERR_PTR(-ENOMEM);
 
   size_t fn_size = strlen(fn)+1;
-  long ret = frontend_syscall(SYS_openat, dirfd, va2pa(fn), fn_size, flags, mode, 0, 0);
+  long ret = frontend_syscall(SYS_openat, dirfd, kva2pa(fn), fn_size, flags, mode, 0, 0);
   if (ret >= 0)
   {
     f->kfd = ret;
@@ -133,26 +133,22 @@ int fd_close(int fd)
 
 ssize_t file_read(file_t* f, void* buf, size_t size)
 {
-  populate_mapping(buf, size, PROT_WRITE);
-  return frontend_syscall(SYS_read, f->kfd, va2pa(buf), size, 0, 0, 0, 0);
+  return frontend_syscall(SYS_read, f->kfd, kva2pa(buf), size, 0, 0, 0, 0);
 }
 
 ssize_t file_pread(file_t* f, void* buf, size_t size, off_t offset)
 {
-  populate_mapping(buf, size, PROT_WRITE);
-  return frontend_syscall(SYS_pread, f->kfd, va2pa(buf), size, offset, 0, 0, 0);
+  return frontend_syscall(SYS_pread, f->kfd, kva2pa(buf), size, offset, 0, 0, 0);
 }
 
 ssize_t file_write(file_t* f, const void* buf, size_t size)
 {
-  populate_mapping(buf, size, PROT_READ);
-  return frontend_syscall(SYS_write, f->kfd, va2pa(buf), size, 0, 0, 0, 0);
+  return frontend_syscall(SYS_write, f->kfd, kva2pa(buf), size, 0, 0, 0, 0);
 }
 
 ssize_t file_pwrite(file_t* f, const void* buf, size_t size, off_t offset)
 {
-  populate_mapping(buf, size, PROT_READ);
-  return frontend_syscall(SYS_pwrite, f->kfd, va2pa(buf), size, offset, 0, 0, 0);
+  return frontend_syscall(SYS_pwrite, f->kfd, kva2pa(buf), size, offset, 0, 0, 0);
 }
 
 int file_truncate(file_t* f, off_t len)

--- a/pk/mmap.c
+++ b/pk/mmap.c
@@ -175,6 +175,7 @@ static int __handle_page_fault(uintptr_t vaddr, int prot)
   else if (!(*pte & PTE_V))
   {
     uintptr_t ppn = vpn + (first_free_paddr / RISCV_PGSIZE);
+    uintptr_t kva = ppn * RISCV_PGSIZE;
 
     vmr_t* v = (vmr_t*)*pte;
     *pte = pte_create(ppn, prot_to_type(PROT_READ|PROT_WRITE, 0));
@@ -182,7 +183,7 @@ static int __handle_page_fault(uintptr_t vaddr, int prot)
     if (v->file)
     {
       size_t flen = MIN(RISCV_PGSIZE, v->length - (vaddr - v->addr));
-      ssize_t ret = file_pread(v->file, (void*)vaddr, flen, vaddr - v->addr + v->offset);
+      ssize_t ret = file_pread(v->file, (void*)kva, flen, vaddr - v->addr + v->offset);
       kassert(ret > 0);
       if (ret < RISCV_PGSIZE)
         memset((void*)vaddr + ret, 0, RISCV_PGSIZE - ret);

--- a/pk/mmap.h
+++ b/pk/mmap.h
@@ -34,8 +34,7 @@ uintptr_t do_mremap(uintptr_t addr, size_t old_size, size_t new_size, int flags)
 uintptr_t do_mprotect(uintptr_t addr, size_t length, int prot);
 uintptr_t do_brk(uintptr_t addr);
 
-#define va2pa(va) ({ uintptr_t __va = (uintptr_t)(va); \
-  extern uintptr_t first_free_paddr; \
-  __va >= MEM_START ? __va : __va + first_free_paddr; })
+#define kva2pa(va) ((uintptr_t)(va))
+#define is_uva(va) ((uintptr_t)(va) < MEM_START)
 
 #endif

--- a/pk/pk.mk.in
+++ b/pk/pk.mk.in
@@ -13,6 +13,7 @@ pk_hdrs = \
 	mmap.h \
 	pk.h \
 	syscall.h \
+	usermem.h \
 
 pk_c_srcs = \
 	file.c \
@@ -22,6 +23,7 @@ pk_c_srcs = \
 	elf.c \
 	console.c \
 	mmap.c \
+	usermem.c \
 
 pk_asm_srcs = \
 	entry.S \

--- a/pk/usermem.c
+++ b/pk/usermem.c
@@ -1,0 +1,66 @@
+// See LICENSE for license details.
+
+#include "usermem.h"
+#include "mmap.h"
+#include <string.h>
+#include <stdint.h>
+
+void memset_user(void* dst, int ch, size_t n)
+{
+  if ((uintptr_t)dst + n < (uintptr_t)dst || !is_uva(dst + n - 1))
+    handle_page_fault((uintptr_t)dst, PROT_WRITE);
+
+  uintptr_t sstatus = set_csr(sstatus, SSTATUS_SUM);
+
+  memset(dst, ch, n);
+
+  write_csr(sstatus, sstatus);
+}
+
+void memcpy_to_user(void* dst, const void* src, size_t n)
+{
+  if ((uintptr_t)dst + n < (uintptr_t)dst || !is_uva(dst + n - 1))
+    handle_page_fault((uintptr_t)dst, PROT_WRITE);
+
+  uintptr_t sstatus = set_csr(sstatus, SSTATUS_SUM);
+
+  memcpy(dst, src, n);
+
+  write_csr(sstatus, sstatus);
+}
+
+void memcpy_from_user(void* dst, const void* src, size_t n)
+{
+  if ((uintptr_t)src + n < (uintptr_t)src || !is_uva(src + n - 1))
+    handle_page_fault((uintptr_t)src, PROT_READ);
+
+  uintptr_t sstatus = set_csr(sstatus, SSTATUS_SUM);
+
+  memcpy(dst, src, n);
+
+  write_csr(sstatus, sstatus);
+}
+
+bool strcpy_from_user(char* dst, const char* src, size_t n)
+{
+  uintptr_t sstatus = set_csr(sstatus, SSTATUS_SUM);
+
+  while (n > 0) {
+    if (!is_uva(src))
+      handle_page_fault((uintptr_t)src, PROT_READ);
+
+    char ch = *(volatile const char*)src;
+    *dst = ch;
+
+    if (ch == 0)
+      return true;
+
+    src++;
+    dst++;
+    n--;
+  }
+
+  write_csr(sstatus, sstatus);
+
+  return false;
+}

--- a/pk/usermem.h
+++ b/pk/usermem.h
@@ -1,0 +1,14 @@
+// See LICENSE for license details.
+
+#ifndef _PK_USERMEM_H
+#define _PK_USERMEM_H
+
+#include <stdbool.h>
+#include <stddef.h>
+
+void memset_user(void* dst, int ch, size_t n);
+void memcpy_to_user(void* dst, const void* src, size_t n);
+void memcpy_from_user(void* dst, const void* src, size_t n);
+bool strcpy_from_user(char* dst, const char* src, size_t n);
+
+#endif


### PR DESCRIPTION
The upstream LiteX project defaults to "litex,liteuart" as the value
for the "compatible" property of the UART DT node.

Signed-off-by: Gabriel Somlo <gsomlo@gmail.com>