### PR TITLE
LiteX UART: fix compatible property name

### DIFF
--- a/machine/uart_litex.c
+++ b/machine/uart_litex.c
@@ -45,7 +45,8 @@ static void uart_litex_prop(const struct fdt_scan_prop *prop, void *extra)
 {
     struct uart_litex_scan *scan = (struct uart_litex_scan *)extra;
     if (!strcmp(prop->name, "compatible") &&
-        !strcmp((const char *)prop->value, "litex,uart0")) {
+        (!strcmp((const char *)prop->value, "litex,uart0") ||
+         !strcmp((const char *)prop->value, "litex,liteuart"))) {
         scan->compat = 1;
     } else if (!strcmp(prop->name, "reg")) {
         fdt_get_address(prop->node->parent, prop->value, &scan->reg);


### PR DESCRIPTION
The upstream LiteX project defaults to "litex,liteuart" as the value
for the "compatible" property of the UART DT node, so let's add it to
the current list of accepted strings.

Signed-off-by: Gabriel Somlo <gsomlo@gmail.com>