### PR TITLE
pk: Fix __clear_cache() compilation issue with recent compilers

### DIFF
--- a/machine/flush_icache.h
+++ b/machine/flush_icache.h
@@ -1,0 +1,8 @@
+// See LICENSE for license details.
+
+#ifndef _RISCV_FLUSH_ICACHE_H
+#define _RISCV_FLUSH_ICACHE_H
+
+void __riscv_flush_icache(void);
+
+#endif /* _RISCV_FLUSH_ICACHE_H */

--- a/pk/pk.c
+++ b/pk/pk.c
@@ -8,6 +8,7 @@
 #include "frontend.h"
 #include "bits.h"
 #include "usermem.h"
+#include "flush_icache.h"
 #include <stdbool.h>
 
 elf_info current;
@@ -174,7 +175,7 @@ static void run_loaded_program(size_t argc, char** argv, uintptr_t kstack_top)
 
   trapframe_t tf;
   init_tf(&tf, current.entry, stack_top);
-  __clear_cache(0, 0);
+  __riscv_flush_icache();
   write_csr(sscratch, kstack_top);
   start_user(&tf);
 }


### PR DESCRIPTION
Using recent compilers we get the following error message:

  ../pk/pk.c: In function 'run_loaded_program.constprop':
  ../pk/pk.c:177:3: error: both arguments to '__builtin___clear_cache'
  must be pointers
    177 |   __clear_cache(0, 0);
        |   ^~~~~~~~~~~~~~~~~~~

Let's use the existing function __riscv_flush_icache(),
give it a header with a prototype and use it to
emits the FENCE.I instruction directly.

See #239

Suggested-by: Andrew Waterman <andrew@sifive.com>
Signed-off-by: Christoph Muellner <cmuellner@linux.com>