### PR TITLE
replace `spbtr` with `satp`

### DIFF
--- a/machine/minit.c
+++ b/machine/minit.c
@@ -46,7 +46,7 @@ static void mstatus_init()
 
   // Disable paging
   if (supports_extension('S'))
-    write_csr(sptbr, 0);
+    write_csr(satp, 0);
 }
 
 // send S-mode interrupts and most exceptions straight to S-mode

--- a/pk/mmap.c
+++ b/pk/mmap.c
@@ -560,7 +560,7 @@ uintptr_t pk_vm_init()
   __map_kernel_range(KVA_START, MEM_START, mem_size, PROT_READ|PROT_WRITE|PROT_EXEC);
 
   flush_tlb();
-  write_csr(sptbr, ((uintptr_t)root_page_table >> RISCV_PGSHIFT) | SATP_MODE_CHOICE);
+  write_csr(satp, ((uintptr_t)root_page_table >> RISCV_PGSHIFT) | SATP_MODE_CHOICE);
 
   uintptr_t kernel_stack_top = __page_alloc_assert() + RISCV_PGSIZE;
 


### PR DESCRIPTION
The LLVM IAS currently does not support the older spelling for the CSR.
Update the references to the modern name.