### PR TITLE
machine: replace `mbadaddr` with `mtval`

### DIFF
--- a/machine/emulation.c
+++ b/machine/emulation.c
@@ -131,7 +131,7 @@ void illegal_insn_trap(uintptr_t* regs, uintptr_t mcause, uintptr_t mepc)
        "  .popsection");
 
   uintptr_t mstatus = read_csr(mstatus);
-  insn_t insn = read_csr(mbadaddr);
+  insn_t insn = read_csr(mtval);
 
   if (unlikely((insn & 3) != 3)) {
     if (insn == 0)

--- a/machine/fp_ldst.c
+++ b/machine/fp_ldst.c
@@ -5,7 +5,7 @@
 
 #define punt_to_misaligned_handler(align, handler) \
   if (addr % (align) != 0) \
-    return write_csr(mbadaddr, addr), (handler)(regs, mcause, mepc)
+    return write_csr(mtval, addr), (handler)(regs, mcause, mepc)
 
 DECLARE_EMULATION_FUNC(emulate_float_load)
 {

--- a/machine/misaligned_ldst.c
+++ b/machine/misaligned_ldst.c
@@ -20,7 +20,7 @@ void misaligned_load_trap(uintptr_t* regs, uintptr_t mcause, uintptr_t mepc)
   uintptr_t mstatus;
   insn_t insn = get_insn(mepc, &mstatus);
   uintptr_t npc = mepc + insn_len(insn);
-  uintptr_t addr = read_csr(mbadaddr);
+  uintptr_t addr = read_csr(mtval);
 
   int shift = 0, fp = 0, len;
   if ((insn & MASK_LW) == MATCH_LW)
@@ -142,7 +142,7 @@ void misaligned_store_trap(uintptr_t* regs, uintptr_t mcause, uintptr_t mepc)
     return truly_illegal_insn(regs, mcause, mepc, mstatus, insn);
   }
 
-  uintptr_t addr = read_csr(mbadaddr);
+  uintptr_t addr = read_csr(mtval);
 #if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
   intptr_t offs = (len == 8? 0 : sizeof(val.intx) - len);
 #else

--- a/machine/mtrap.c
+++ b/machine/mtrap.c
@@ -196,7 +196,7 @@ void redirect_trap(uintptr_t epc, uintptr_t mstatus, uintptr_t badaddr)
 
 void pmp_trap(uintptr_t* regs, uintptr_t mcause, uintptr_t mepc)
 {
-  redirect_trap(mepc, read_csr(mstatus), read_csr(mbadaddr));
+  redirect_trap(mepc, read_csr(mstatus), read_csr(mtval));
 }
 
 static void machine_page_fault(uintptr_t* regs, uintptr_t mcause, uintptr_t mepc)
@@ -218,7 +218,7 @@ static void machine_page_fault(uintptr_t* regs, uintptr_t mcause, uintptr_t mepc
       goto fail;
     }
 
-    return redirect_trap(regs[12], regs[13], read_csr(mbadaddr));
+    return redirect_trap(regs[12], regs[13], read_csr(mtval));
   }
 
 fail:


### PR DESCRIPTION
The LLVM IAS does not support the older name for the `mtval` CSR.  This
updates the name to the current spelling, which is required to build
with the LLVM IAS.  This remains compatible with binutils as well.