### PR TITLE
replace `sbadaddr` with `stval`

### DIFF
--- a/machine/mtrap.c
+++ b/machine/mtrap.c
@@ -178,7 +178,7 @@ send_ipi:
 
 void redirect_trap(uintptr_t epc, uintptr_t mstatus, uintptr_t badaddr)
 {
-  write_csr(sbadaddr, badaddr);
+  write_csr(stval, badaddr);
   write_csr(sepc, epc);
   write_csr(scause, read_csr(mcause));
   write_csr(mepc, read_csr(stvec));

--- a/pk/entry.S
+++ b/pk/entry.S
@@ -40,7 +40,7 @@
   csrrw  t0,sscratch,x0
   csrr   s0,sstatus
   csrr   t1,sepc
-  csrr   t2,sbadaddr
+  csrr   t2,stval
   csrr   t3,scause
   STORE  t0,2*REGBYTES(x2)
   STORE  s0,32*REGBYTES(x2)


### PR DESCRIPTION
This replaces use of the old `sbadaddr` CSR name with the current
`stval` name.  The old spelling is not supported by the LLVM IAS,
however, the modern spelling is supported by both LLVM and binutils.