### PR TITLE
machine: manually perform assembler relaxation

### DIFF
--- a/machine/mentry.S
+++ b/machine/mentry.S
@@ -312,7 +312,9 @@ do_reset:
   # make sure our hart id is within a valid range
   fence
   li a2, MAX_HARTS
-  bltu a3, a2, init_other_hart
+  bgeu a3, a2, .Lcont
+  j init_other_hart
+.Lcont:
 #endif
   wfi
   j .LmultiHart


### PR DESCRIPTION
This is an equivalent rewrite of the existing code.  When building with
gas, the `bltu` would implicitly get relaxed to the `bgeu` + `j`.  This
relaxation is required as the `init_other_hart` is not guaranteed to be
addressable in 12-bits.  When building with the LLVM IAS instead of gas
we fail to link as the branch is not relaxed.  This change enables LLVM
to build and link this code with the LLVM IAS and lld.