### PR TITLE
pk: correct the handling of SYS_getcwd

### DIFF
--- a/pk/syscall.c
+++ b/pk/syscall.c
@@ -420,7 +420,7 @@ long sys_getcwd(char* buf, size_t size)
 {
   char kbuf[MAX_BUF];
   long ret = frontend_syscall(SYS_getcwd, kva2pa(kbuf), MIN(size, MAX_BUF), 0, 0, 0, 0, 0);
-  if (ret == 0)
+  if (ret > 0)
     memcpy_to_user(buf, kbuf, strlen(kbuf) + 1);
   return ret;
 }


### PR DESCRIPTION
`SYS_getcwd` is different from `getcwd` in that the return value is < 0
on failure otherwise it is the length of the string.  The proxy kernel
was treating 0 as success and all other values as error.  As a result,
we would never return a valid value for `getcwd`.

The following program now executes properly with the Proxy Kernel:
  ```c
  #include <stdio.h>
  #include <stdlib.h>
  #include <unistd.h>

  #include <linux/limits.h>

  int main(int argc, char **argv) {
    unsigned char buffer[PATH_MAX + 1] = {0};
    if (getcwd(buffer, PATH_MAX))
      printf("cwd: %s\n", buffer);
    return EXIT_SUCCESS;
  }
  ```